### PR TITLE
fix: return `msg.value` to bundler if metacall fails

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,6 @@
 [profile.default]
   bytecode_hash = "none"
-  optimizer_runs = 20
+  optimizer_runs = 18
   timeout = 30000
   block_gas_limit = 300000000
   gas_limit = 3000000000

--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -65,8 +65,7 @@ contract Atlas is Escrow, Factory {
         // is deducted from this _gasMarker, resulting in actual execution gas used + calldata gas costs + buffer.
         // The calldata component is added below, only if exPostBids = false.
         uint256 _gasLeft = gasleft();
-        uint256 _gasMarker = _gasLeft + _BASE_TX_GAS_USED + _POST_SETTLE_METACALL_GAS; // This part is only execution
-            // gas.
+        uint256 _gasMarker = _gasLeft + _BASE_TX_GAS_USED + _POST_SETTLE_METACALL_GAS; // This is only execution gas.
 
         DAppConfig memory _dConfig;
         bool _isSimulation = msg.sender == SIMULATOR;
@@ -106,6 +105,8 @@ contract Atlas is Escrow, Factory {
 
             // Gracefully return for results that need nonces to be stored and prevent replay attacks
             if (uint8(_validCallsResult) >= _GRACEFUL_RETURN_THRESHOLD && !_dConfig.callConfig.allowsReuseUserOps()) {
+                // Refund the bundler if they sent any msg.value, then return false and end early.
+                if (msg.value != 0) SafeTransferLib.safeTransferETH(msg.sender, msg.value);
                 return false;
             }
 

--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -20,7 +20,7 @@ import { CallBits } from "../libraries/CallBits.sol";
 import { SafetyBits } from "../libraries/SafetyBits.sol";
 import { GasAccLib, GasLedger } from "../libraries/GasAccLib.sol";
 
-/// @title Atlas V1.6.2
+/// @title Atlas V1.6.3
 /// @author FastLane Labs
 /// @notice The Execution Abstraction protocol.
 contract Atlas is Escrow, Factory {

--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -36,7 +36,7 @@ contract AtlasVerification is EIP712, NonceManager, DAppIntegration {
         address atlas,
         address l2GasCalculator
     )
-        EIP712("AtlasVerification", "1.6.2")
+        EIP712("AtlasVerification", "1.6.3")
         DAppIntegration(atlas, l2GasCalculator)
     { }
 

--- a/test/Atlas.t.sol
+++ b/test/Atlas.t.sol
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import "forge-std/Test.sol";
+
+import { DAppControl } from "../src/contracts/dapp/DAppControl.sol";
+import { UserOperation } from "../src/contracts/types/UserOperation.sol";
+import { SolverOperation } from "../src/contracts/types/SolverOperation.sol";
+import { DAppOperation } from "../src/contracts/types/DAppOperation.sol";
+import { CallConfig } from "../src/contracts/types/ConfigTypes.sol";
+import { CallVerification } from "../src/contracts/libraries/CallVerification.sol";
+
+import { BaseTest } from "./base/BaseTest.t.sol";
+
+// Tests for logic in the Atlas.sol contract
+contract AtlasTest is BaseTest {
+    Sig sig;
+    TestDAppControl dappControl;
+
+    function setUp() public override {
+        // Run the base setup
+        super.setUp();
+
+        vm.startPrank(governanceEOA);
+        dappControl = new TestDAppControl(address(atlas));
+        atlasVerification.initializeGovernance(address(dappControl));
+        vm.stopPrank();
+    }
+
+    function test_Atlas_BundlerRefundedIfMetacallFails() public {
+        UserOperation memory userOp = _buildUserOp();
+        DAppOperation memory dAppOp = _buildDAppOp(userOp);
+
+        // Changing UserOp after DAppOp is signed will invalidate the metacall
+        userOp.data = new bytes(12345);
+
+        deal(userEOA, 1e18);
+        uint256 bundlerBalanceBefore = address(userEOA).balance;
+
+        // User is bundler, sends 1 ETH value with metacall
+        vm.startPrank(userEOA);
+        bool success = atlas.metacall{value: 1e18}(
+            userOp,
+            new SolverOperation[](0),
+            dAppOp,
+            userEOA
+        );
+
+        // Metacall should fail, return false instead of reverting, and refund the bundler
+        assertEq(success, false, "Metacall should fail");
+        assertEq(
+            address(userEOA).balance,
+            bundlerBalanceBefore,
+            "Bundler should be refunded, no balance change"
+        );
+    }
+
+    // ---------------------------------------------------- //
+    //                        Helpers                       //
+    // ---------------------------------------------------- //
+
+    function _buildUserOp() internal view returns (UserOperation memory) {
+        return UserOperation({
+            from: userEOA,
+            to: address(atlas),
+            value: 0,
+            gas: 1_000_000,
+            maxFeePerGas: tx.gasprice,
+            nonce: 1,
+            deadline: block.timestamp + 2,
+            dapp: address(dappControl),
+            control: address(dappControl),
+            callConfig: dappControl.CALL_CONFIG(),
+            dappGasLimit: dappControl.getDAppGasLimit(),
+            solverGasLimit: dappControl.getSolverGasLimit(),
+            bundlerSurchargeRate: dappControl.getBundlerSurchargeRate(),
+            sessionKey: address(0),
+            data: "",
+            signature: new bytes(0)
+        });
+    }
+
+    function _buildDAppOp(UserOperation memory userOp) internal returns (DAppOperation memory dAppOp) {
+        dAppOp = DAppOperation({
+            from: governanceEOA,
+            to: address(atlas),
+            nonce: 1,
+            deadline: block.timestamp + 2,
+            control: address(dappControl),
+            bundler: address(0),
+            userOpHash: atlasVerification.getUserOperationHash(userOp),
+            callChainHash: CallVerification.getCallChainHash(userOp, new SolverOperation[](0)),
+            signature: new bytes(0)
+        });
+        (sig.v, sig.r, sig.s) = vm.sign(governancePK, atlasVerification.getDAppOperationPayload(dAppOp));
+        dAppOp.signature = abi.encodePacked(sig.r, sig.s, sig.v);
+    }
+}
+
+
+contract TestDAppControl is DAppControl {
+    constructor(address atlas) DAppControl(
+        atlas,
+        msg.sender,
+        CallConfig({
+                userNoncesSequential: false,
+                dappNoncesSequential: false,
+                requirePreOps: false,
+                trackPreOpsReturnData: false,
+                trackUserReturnData: false,
+                delegateUser: false,
+                requirePreSolver: false,
+                requirePostSolver: false,
+                zeroSolvers: true,
+                reuseUserOp: false, // makes metacall return false instead of revert
+                userAuctioneer: true,
+                solverAuctioneer: false,
+                unknownAuctioneer: false,
+                verifyCallChainHash: true,
+                forwardReturnData: false,
+                requireFulfillment: false,
+                trustedOpHash: false,
+                invertBidValue: false,
+                exPostBids: false,
+                multipleSuccessfulSolvers: false,
+                checkMetacallGasLimit: false
+            })) {}
+
+    function _allocateValueCall(
+        bool solved,
+        address bidToken,
+        uint256 bidAmount,
+        bytes calldata data
+    ) internal virtual override {}
+
+    function getBidFormat(
+        UserOperation calldata
+    ) public view virtual override returns (address bidToken) {
+        return address(0);
+    }
+
+    function getBidValue(
+        SolverOperation calldata solverOp
+    ) public view virtual override returns (uint256) {
+        return solverOp.bidAmount;
+    }
+}

--- a/test/AtlasVerification.t.sol
+++ b/test/AtlasVerification.t.sol
@@ -1901,7 +1901,7 @@ contract AtlasVerificationValidCallsTest is AtlasVerificationBase {
 
     function testGetDomainSeparatorInAtlasVerification() public view {
         bytes32 hashedName = keccak256(bytes("AtlasVerification"));
-        bytes32 hashedVersion = keccak256(bytes("1.6.2"));
+        bytes32 hashedVersion = keccak256(bytes("1.6.3"));
         bytes32 typeHash = keccak256(
             "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
         );


### PR DESCRIPTION
### Bug Description

If `allowsReuseUserOps` is set to false and the metacall fails at the AtlasVerification step, the metacall returns false instead of reverting so that the userOp's nonce is stored so the userOp cannot be reused. This failure return happens early in the metacall function, and does not refund the bundler if they included any `msg.value` in the metacall. This refund was only missing in the early false return, and not the false return found at the end of the metacall function which already correctly refunds the bundler if required.

### Bug fix

If the metacall is going to fail and the call config settings require that it returns false instead of reverting, we now also refund the bundler with any `msg.value` they sent with the metacall, in all cases.

Added a new `test_Atlas_BundlerRefundedIfMetacallFails` test in `Atlas.t.sol` which fails if the new `msg.value` refund line is removed, but passes if the fix is in place.

### Other Changes

- Reduced `optimizer_runs` from 20 to 18, as the new refund line would otherwise push Atlas over the contract size limit.
- Bumped the Atlas version string everywhere from `1.6.2` to `1.6.3`.