### PR TITLE
feat: add Plume and Plume Testnet support

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,6 @@
 [profile.default]
   bytecode_hash = "none"
-  optimizer_runs = 20
+  optimizer_runs = 18
   timeout = 30000
   block_gas_limit = 300000000
   gas_limit = 3000000000

--- a/script/base/deploy-base.s.sol
+++ b/script/base/deploy-base.s.sol
@@ -73,6 +73,10 @@ contract DeployBaseScript is Script {
             return "UNICHAIN";
         } else if (chainId == 1301) {
             return "UNICHAIN SEPOLIA";
+        } else if (chainId == 98_866) {
+            return "PLUME";
+        } else if (chainId == 98_867) {
+            return "PLUME TESTNET";
         } else {
             revert(string.concat("Error: Chain ID not recognized: ", vm.toString(chainId)));
         }

--- a/src/contracts/libraries/SafeBlockNumber.sol
+++ b/src/contracts/libraries/SafeBlockNumber.sol
@@ -10,12 +10,14 @@ library SafeBlockNumber {
     uint256 internal constant ARBITRUM_ONE_CHAIN_ID = 42_161;
     uint256 internal constant ARBITRUM_NOVA_CHAIN_ID = 42_170;
     uint256 internal constant ARBITRUM_SEPOLIA_CHAIN_ID = 421_614;
+    uint256 internal constant PLUME_CHAIN_ID = 98_866;
+    uint256 internal constant PLUME_TESTNET_CHAIN_ID = 98_867;
 
     function get() internal view returns (uint256) {
         uint256 chainId = block.chainid;
         if (
             chainId == ARBITRUM_ONE_CHAIN_ID || chainId == ARBITRUM_NOVA_CHAIN_ID
-                || chainId == ARBITRUM_SEPOLIA_CHAIN_ID
+                || chainId == ARBITRUM_SEPOLIA_CHAIN_ID || chainId == PLUME_CHAIN_ID || chainId == PLUME_TESTNET_CHAIN_ID
         ) {
             // Arbitrum One or Nova chain
             return ARB_SYS.arbBlockNumber();


### PR DESCRIPTION
### Changes

- Added Plume and Plume Testnet chainIds to the SafeBlockNumber library (as Plume is an L2 built on the Arbitrum stack).
- Added Plume and Plume Testnet chainIds to allowed deployment chains.
- Decreased optimizer runs from 20 to 18 to alleviate the increase in contract size which initially went over the limit.