### PR TITLE
fix: resolve foundry timeout warning and V4 example logic bug

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,7 +1,7 @@
 [profile.default]
   bytecode_hash = "none"
   optimizer_runs = 18
-  timeout = 30000
+
   block_gas_limit = 300000000
   gas_limit = 3000000000
   gas_price = 1500000000

--- a/src/contracts/examples/v4-example/V4DAppControl.sol
+++ b/src/contracts/examples/v4-example/V4DAppControl.sol
@@ -175,7 +175,11 @@ contract V4DAppControl is DAppControl {
         }
         require(!initialized, "ERR-H09 AlreadyInitialized");
 
-        IPoolManager.PoolKey memory key; // todo: finish
+        (bytes memory returnData) = abi.decode(data, (bytes));
+
+        PreOpsReturn memory preOpsReturn = abi.decode(returnData, (PreOpsReturn));
+
+        IPoolManager.PoolKey memory key = preOpsReturn.poolKey;
 
         if (bidToken == IPoolManager.Currency.unwrap(key.currency0)) {
             IPoolManager(v4Singleton).donate(key, bidAmount, 0);
@@ -195,10 +199,6 @@ contract V4DAppControl is DAppControl {
         sequenceLock[sequenceKey] = true;
 
         // NOTE: The code below was previously in the postOps hook
-
-        (bytes memory returnData) = abi.decode(data, (bytes));
-
-        PreOpsReturn memory preOpsReturn = abi.decode(returnData, (PreOpsReturn));
 
         V4DAppControl(hook).releaseLock(preOpsReturn.poolKey);
 


### PR DESCRIPTION
This PR addresses two issues found in the codebase:

1. Fix Foundry Configuration Warning

Removed the deprecated timeout configuration in 
foundry.toml
 which was causing a "Found unknown timeout config" warning during build.
2. Fix Logic Bug in V4DAppControl.sol

Issue: In _allocateValueCall, the key struct was being used before it was initialized (it was declared but not assigned a value).
Fix: Moved the decoding logic of preOpsReturn to before the key usage, ensuring key is correctly populated with preOpsReturn.poolKey.
Verification
Build: forge build passes successfully without warnings.
Test: Logic verified with a standalone test (Mock environment) confirming donate is called with the correct parameters.