### PR TITLE
fix: remove redundant receive function in Escrow.sol

### DIFF
--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -746,5 +746,4 @@ abstract contract Escrow is AtlETH {
         ctx.dappGasLeft -= uint32(_gasUsed);
     }
 
-    receive() external payable { }
 }


### PR DESCRIPTION
Ref #506. The `receive()` function in `Escrow.sol` is redundant as Atlas handles ETH accounting through `AtlETH`. Removing it prevents users from accidentally sending ETH to the contract and potentially losing access to those funds.