### PR TITLE
refactor: remove unused receive() function in Escrow.sol

### DIFF
--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -746,5 +746,4 @@ abstract contract Escrow is AtlETH {
         ctx.dappGasLeft -= uint32(_gasUsed);
     }
 
-    receive() external payable { }
 }


### PR DESCRIPTION
As discussed in issue #506, the  function in  does not serve any purpose since legitimate fund transfers to Atlas are sent via payable function calls. Removing it reduces the risk of user funds being lost when accidentally sent to the contract address without data. This change helps prevent accidental ETH transfers that wouldn't be credited as atlETH.