### PR TITLE
Remove unnecessary receive() in Escrow.sol

### DIFF
--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -746,5 +746,4 @@ abstract contract Escrow is AtlETH {
         ctx.dappGasLeft -= uint32(_gasUsed);
     }
 
-    receive() external payable { }
 }


### PR DESCRIPTION
Fixes #506. The receive() function in Escrow.sol is not needed as all legitimate transfers are handled via payable functions. Removing it reduces the risk of users accidentally sending ETH directly to the contract and having it stuck.