### PR TITLE
feat: update bond/unbond/redeem to match ShMonad naming conventions

### DIFF
--- a/src/contracts/atlas/AtlETH.sol
+++ b/src/contracts/atlas/AtlETH.sol
@@ -32,17 +32,17 @@ abstract contract AtlETH is Permit69 {
         return uint256(s_balanceOf[account].balance);
     }
 
-    /// @notice Returns the bonded AtlETH balance of the specified account.
-    /// @param account The address for which to query the bonded AtlETH balance.
-    /// @return The bonded AtlETH balance of the specified account.
-    function balanceOfBonded(address account) external view returns (uint256) {
+    /// @notice Returns the committed AtlETH balance of the specified account.
+    /// @param account The address for which to query the committed AtlETH balance.
+    /// @return The committed AtlETH balance of the specified account.
+    function balanceOfCommitted(address account) external view returns (uint256) {
         return uint256(S_accessData[account].bonded);
     }
 
-    /// @notice Returns the unbonding AtlETH balance of the specified account.
-    /// @param account The address for which to query the unbonding AtlETH balance.
-    /// @return The unbonding AtlETH balance of the specified account.
-    function balanceOfUnbonding(address account) external view returns (uint256) {
+    /// @notice Returns the uncommitting AtlETH balance of the specified account.
+    /// @param account The address for which to query the uncommitting AtlETH balance.
+    /// @return The uncommitting AtlETH balance of the specified account.
+    function balanceOfUncommitting(address account) external view returns (uint256) {
         return uint256(s_balanceOf[account].unbonding);
     }
 
@@ -53,10 +53,10 @@ abstract contract AtlETH is Permit69 {
         return uint256(S_accessData[account].lastAccessedBlock);
     }
 
-    /// @notice Returns the block number at which the unbonding process of the specified account will be completed.
-    /// @param account The address for which to query the completion block of unbonding.
-    /// @return The block number at which the unbonding process of the specified account will be completed.
-    function unbondingCompleteBlock(address account) external view returns (uint256) {
+    /// @notice Returns the block number at which the uncommitting process of the specified account will be completed.
+    /// @param account The address for which to query the completion block of uncommitting.
+    /// @return The block number at which the uncommitting process of the specified account will be completed.
+    function uncommitCompleteBlock(address account) external view returns (uint256) {
         uint256 _lastAccessedBlock = uint256(S_accessData[account].lastAccessedBlock);
         if (_lastAccessedBlock == 0) return 0;
         return _lastAccessedBlock + ESCROW_DURATION;
@@ -132,43 +132,43 @@ abstract contract AtlETH is Permit69 {
     }
 
     /*//////////////////////////////////////////////////////////////
-                    EXTERNAL BOND/UNBOND LOGIC
+                    EXTERNAL COMMIT/UNCOMMIT LOGIC
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Puts a "hold" on a solver's AtlETH, enabling it to be used in Atlas transactions.
-    /// @dev This function locks the specified amount of AtlETH tokens for the sender, making them bonded.
-    /// Bonded AtlETH tokens must first be unbonded before they can be transferred or withdrawn.
-    /// @param amount The amount of AtlETH tokens to bond.
-    function bond(uint256 amount) external {
-        _bond(msg.sender, amount);
+    /// @dev This function locks the specified amount of AtlETH tokens for the sender, making them committed.
+    /// Committed AtlETH tokens must first be uncommitted before they can be transferred or withdrawn.
+    /// @param amount The amount of AtlETH tokens to commit.
+    function commit(uint256 amount) external {
+        _commit(msg.sender, amount);
     }
 
-    /// @notice Deposits the caller's ETH and mints AtlETH, then bonds a specified amount of that AtlETH.
-    /// @param amountToBond The amount of AtlETH tokens to bond after the deposit.
-    function depositAndBond(uint256 amountToBond) external payable {
+    /// @notice Deposits the caller's ETH and mints AtlETH, then commits a specified amount of that AtlETH.
+    /// @param amountToCommit The amount of AtlETH tokens to commit after the deposit.
+    function depositAndCommit(uint256 amountToCommit) external payable {
         _mint(msg.sender, msg.value);
-        _bond(msg.sender, amountToBond);
+        _commit(msg.sender, amountToCommit);
     }
 
-    /// @notice Starts the unbonding wait time for the specified amount of AtlETH tokens.
-    /// @dev This function initiates the unbonding process for the specified amount of AtlETH tokens
-    /// held by the sender. Unbonding AtlETH tokens can still be used by solvers while the unbonding
+    /// @notice Starts the uncommitting wait time for the specified amount of AtlETH tokens.
+    /// @dev This function initiates the uncommitting process for the specified amount of AtlETH tokens
+    /// held by the sender. Uncommitting AtlETH tokens can still be used by solvers while the uncommitting
     /// process is ongoing, but adjustments may be made at withdrawal to ensure solvency.
-    /// @param amount The amount of AtlETH tokens to unbond.
-    function unbond(uint256 amount) external {
+    /// @param amount The amount of AtlETH tokens to request uncommit for.
+    function requestUncommit(uint256 amount) external {
         _checkIfUnlocked();
-        _unbond(msg.sender, amount);
+        _requestUncommit(msg.sender, amount);
     }
 
     /// @notice Redeems the specified amount of AtlETH tokens for withdrawal.
-    /// @param amount The amount of AtlETH tokens to redeem for withdrawal.
-    function redeem(uint256 amount) external {
+    /// @param amount The amount of AtlETH tokens to complete uncommit for.
+    function completeUncommit(uint256 amount) external {
         _checkIfUnlocked();
-        _redeem(msg.sender, amount);
+        _completeUncommit(msg.sender, amount);
     }
 
     /*//////////////////////////////////////////////////////////////
-                    INTERNAL BOND/UNBOND LOGIC
+                    INTERNAL COMMIT/UNCOMMIT LOGIC
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Puts a hold on a solver's AtlETH tokens, enabling them to be used in Atlas transactions.
@@ -177,7 +177,7 @@ abstract contract AtlETH is Permit69 {
     /// and added to the bonded balance. The total supply and bonded total supply are updated accordingly.
     /// @param owner The address of the account to put a hold on AtlETH tokens for.
     /// @param amount The amount of AtlETH tokens to put a hold on.
-    function _bond(address owner, uint256 amount) internal {
+    function _commit(address owner, uint256 amount) internal {
         uint112 _amt = SafeCast.toUint112(amount);
 
         s_balanceOf[owner].balance -= _amt;
@@ -186,16 +186,16 @@ abstract contract AtlETH is Permit69 {
         S_accessData[owner].bonded += _amt;
         S_bondedTotalSupply += amount;
 
-        emit Bond(owner, amount);
+        emit Commit(owner, amount);
     }
 
-    /// @notice Starts the unbonding wait time for a specified amount of AtlETH tokens.
-    /// @dev This internal function starts the unbonding wait time for a specified amount of AtlETH tokens.
+    /// @notice Starts the uncommitting wait time for a specified amount of AtlETH tokens.
+    /// @dev This internal function starts the uncommitting wait time for a specified amount of AtlETH tokens.
     /// The specified amount of AtlETH tokens is deducted from the owner's bonded balance and added to the
     /// unbonding balance. The last accessed block for the owner is updated to the current block number.
-    /// @param owner The address of the account to start the unbonding wait time for.
-    /// @param amount The amount of AtlETH tokens to start the unbonding wait time for.
-    function _unbond(address owner, uint256 amount) internal {
+    /// @param owner The address of the account to start the uncommitting wait time for.
+    /// @param amount The amount of AtlETH tokens to start the uncommitting wait time for.
+    function _requestUncommit(address owner, uint256 amount) internal {
         uint112 _amt = SafeCast.toUint112(amount);
 
         // totalSupply and totalBondedSupply are unaffected; continue to count the
@@ -209,17 +209,17 @@ abstract contract AtlETH is Permit69 {
 
         s_balanceOf[owner].unbonding += _amt;
 
-        emit Unbond(owner, amount, SafeBlockNumber.get() + ESCROW_DURATION + 1);
+        emit UncommitRequested(owner, amount, SafeBlockNumber.get() + ESCROW_DURATION + 1);
     }
 
     /// @notice Redeems the specified amount of AtlETH tokens for withdrawal.
     /// @dev This function allows the owner to redeem a specified amount of AtlETH tokens
-    /// for withdrawal. If the unbonding process is active for the specified account, the
+    /// for withdrawal. If the uncommitting process is active for the specified account, the
     /// function will revert. Otherwise, the specified amount of AtlETH tokens will be added
     /// back to the account's balance, and the total supply will be updated accordingly.
     /// @param owner The address of the account redeeming AtlETH tokens for withdrawal.
     /// @param amount The amount of AtlETH tokens to redeem for withdrawal.
-    function _redeem(address owner, uint256 amount) internal {
+    function _completeUncommit(address owner, uint256 amount) internal {
         if (SafeBlockNumber.get() <= uint256(S_accessData[owner].lastAccessedBlock) + ESCROW_DURATION) {
             revert EscrowLockActive();
         }
@@ -234,7 +234,7 @@ abstract contract AtlETH is Permit69 {
         s_bData.balance += _amt;
         S_totalSupply += amount;
 
-        emit Redeem(owner, amount);
+        emit UncommitCompleted(owner, amount);
     }
 
     /// @notice Allows the current surcharge recipient to withdraw the accumulated surcharge. NOTE: If the only ETH in

--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -746,5 +746,4 @@ abstract contract Escrow is AtlETH {
         ctx.dappGasLeft -= uint32(_gasUsed);
     }
 
-    receive() external payable { }
 }

--- a/src/contracts/interfaces/IAtlas.sol
+++ b/src/contracts/interfaces/IAtlas.sol
@@ -34,16 +34,16 @@ interface IAtlas {
 
     // AtlETH.sol
     function balanceOf(address account) external view returns (uint256);
-    function balanceOfBonded(address account) external view returns (uint256);
-    function balanceOfUnbonding(address account) external view returns (uint256);
+    function balanceOfCommitted(address account) external view returns (uint256);
+    function balanceOfUncommitting(address account) external view returns (uint256);
     function accountLastActiveBlock(address account) external view returns (uint256);
-    function unbondingCompleteBlock(address account) external view returns (uint256);
+    function uncommitCompleteBlock(address account) external view returns (uint256);
     function deposit() external payable;
     function withdraw(uint256 amount) external;
-    function bond(uint256 amount) external;
-    function depositAndBond(uint256 amountToBond) external payable;
-    function unbond(uint256 amount) external;
-    function redeem(uint256 amount) external;
+    function commit(uint256 amount) external;
+    function depositAndCommit(uint256 amountToCommit) external payable;
+    function requestUncommit(uint256 amount) external;
+    function completeUncommit(uint256 amount) external;
 
     function withdrawSurcharge() external;
     function transferSurchargeRecipient(address newRecipient) external;

--- a/src/contracts/types/AtlasEvents.sol
+++ b/src/contracts/types/AtlasEvents.sol
@@ -12,9 +12,9 @@ contract AtlasEvents {
     );
 
     // AtlETH
-    event Bond(address indexed owner, uint256 amount);
-    event Unbond(address indexed owner, uint256 amount, uint256 earliestAvailable);
-    event Redeem(address indexed owner, uint256 amount);
+    event Commit(address indexed owner, uint256 amount);
+    event UncommitRequested(address indexed owner, uint256 amount, uint256 earliestAvailable);
+    event UncommitCompleted(address indexed owner, uint256 amount);
     event Mint(address indexed to, uint256 amount);
     event Burn(address indexed from, uint256 amount);
 

--- a/test/Accounting.t.sol
+++ b/test/Accounting.t.sol
@@ -159,7 +159,7 @@ contract AccountingTest is BaseTest {
             abi.encodeCall(HonestRFQSolver.fulfillRFQ, (swapIntent, executionEnvironment));
 
         vm.prank(solverOneEOA);
-        atlas.bond(1 ether);
+        atlas.commit(1 ether);
 
         // Builds the SolverCall
         solverOps[0] = txBuilder.buildSolverOperation({

--- a/test/AtlETH.t.sol
+++ b/test/AtlETH.t.sol
@@ -60,8 +60,8 @@ contract AtlETHTest is BaseTest {
         // Test withdraw 2x AtlETH balance - should revert with custom error
         vm.revertTo(snapshot);
         vm.startPrank(solverTwoEOA);
-        atlas.bond(1e18);
-        atlas.unbond(1e18);
+        atlas.commit(1e18);
+        atlas.requestUncommit(1e18);
         vm.expectRevert(abi.encodeWithSelector(AtlasErrors.InsufficientBalanceForDeduction.selector, 0, 2e18));
         atlas.withdraw(solverTwoAtlETH * 2);
         vm.stopPrank();
@@ -69,127 +69,127 @@ contract AtlETHTest is BaseTest {
         // Test withdraw after unbonding and waiting the escrow duration
         vm.revertTo(snapshot);
         vm.startPrank(solverTwoEOA);
-        atlas.bond(1e18);
-        atlas.unbond(1e18);
+        atlas.commit(1e18);
+        atlas.requestUncommit(1e18);
         vm.stopPrank();
 
-        assertEq(atlas.balanceOfUnbonding(solverTwoEOA), 1e18, "unbonding atleth should be 1 ETH");
+        assertEq(atlas.balanceOfUncommitting(solverTwoEOA), 1e18, "unbonding atleth should be 1 ETH");
         vm.roll(block.number + atlas.ESCROW_DURATION() + 1);
-        assertEq(atlas.balanceOfUnbonding(solverTwoEOA), 1e18, "unbonding atleth should still be 1 ETH");
+        assertEq(atlas.balanceOfUncommitting(solverTwoEOA), 1e18, "unbonding atleth should still be 1 ETH");
         solverEthBalanceBefore = address(solverTwoEOA).balance;
 
         vm.prank(solverTwoEOA);
         atlas.withdraw(solverTwoAtlETH);
 
         assertEq(atlas.balanceOf(solverTwoEOA), 0, "solverTwo's atlETH balance should be 0");
-        assertEq(atlas.balanceOfUnbonding(solverTwoEOA), 0, "unbonding atleth should be 0");
+        assertEq(atlas.balanceOfUncommitting(solverTwoEOA), 0, "unbonding atleth should be 0");
         assertEq(address(solverTwoEOA).balance, solverEthBalanceBefore + 1e18, "solverTwo's ETH balance should be 1 ETH more");
     }
 
     function test_atleth_bond() public {
         assertEq(atlas.balanceOf(solverOneEOA), 1e18, "solverOne's atlETH balance should be 1 ETH");
-        assertEq(atlas.balanceOfBonded(solverOneEOA), 0, "solverOne's bonded atlETH should be 0");
+        assertEq(atlas.balanceOfCommitted(solverOneEOA), 0, "solverOne's bonded atlETH should be 0");
         assertEq(atlas.bondedTotalSupply(), 0, "total bonded atlETH supply should be 0");
 
         vm.prank(solverOneEOA);
         vm.expectRevert(); // Underflow error
-        atlas.bond(2e18);
+        atlas.commit(2e18);
 
         vm.prank(solverOneEOA);
         vm.expectEmit(true, true, false, true);
-        emit AtlasEvents.Bond(solverOneEOA, 1e18);
-        atlas.bond(1e18);
+        emit AtlasEvents.Commit(solverOneEOA, 1e18);
+        atlas.commit(1e18);
 
         assertEq(atlas.balanceOf(solverOneEOA), 0, "solverOne's atlETH balance should be 0");
-        assertEq(atlas.balanceOfBonded(solverOneEOA), 1e18, "solverOne's bonded atlETH should be 1 ETH");
+        assertEq(atlas.balanceOfCommitted(solverOneEOA), 1e18, "solverOne's bonded atlETH should be 1 ETH");
         assertEq(atlas.bondedTotalSupply(), 1e18, "total bonded atlETH supply should be 1 ETH");
     }
 
-    function test_atleth_depositAndBond() public {
+    function test_atleth_depositAndCommit() public {
         assertEq(atlas.balanceOf(userEOA), 0, "user's atlETH balance should be 0");
-        assertEq(atlas.balanceOfBonded(userEOA), 0, "user's bonded atlETH should be 0");
+        assertEq(atlas.balanceOfCommitted(userEOA), 0, "user's bonded atlETH should be 0");
         assertEq(atlas.bondedTotalSupply(), 0, "total bonded atlETH supply should be 0");
 
         deal(userEOA, 1e18);
 
         vm.prank(userEOA);
         vm.expectRevert(); // Underflow error
-        atlas.depositAndBond{ value: 1e18 }(2e18);
+        atlas.depositAndCommit{ value: 1e18 }(2e18);
 
         vm.prank(userEOA);
         vm.expectEmit(true, true, false, true);
         emit AtlasEvents.Mint(userEOA, 1e18);
         vm.expectEmit(true, true, false, true);
-        emit AtlasEvents.Bond(userEOA, 1e18);
-        atlas.depositAndBond{ value: 1e18 }(1e18);
+        emit AtlasEvents.Commit(userEOA, 1e18);
+        atlas.depositAndCommit{ value: 1e18 }(1e18);
 
         assertEq(atlas.balanceOf(userEOA), 0, "user's atlETH balance should still be 0");
-        assertEq(atlas.balanceOfBonded(userEOA), 1e18, "user's bonded atlETH should be 1 ETH");
+        assertEq(atlas.balanceOfCommitted(userEOA), 1e18, "user's bonded atlETH should be 1 ETH");
         assertEq(atlas.bondedTotalSupply(), 1e18, "total bonded atlETH supply should be 1 ETH");
     }
 
     function test_atleth_unbond() public {
         vm.startPrank(solverOneEOA);
-        atlas.bond(1e18);
+        atlas.commit(1e18);
 
         assertEq(atlas.balanceOf(solverOneEOA), 0, "solverOne's atlETH balance should be 0");
-        assertEq(atlas.balanceOfBonded(solverOneEOA), 1e18, "solverOne's bonded atlETH should be 1 ETH");
-        assertEq(atlas.balanceOfUnbonding(solverOneEOA), 0, "solverOne's unbonding atlETH should be 0");
+        assertEq(atlas.balanceOfCommitted(solverOneEOA), 1e18, "solverOne's bonded atlETH should be 1 ETH");
+        assertEq(atlas.balanceOfUncommitting(solverOneEOA), 0, "solverOne's unbonding atlETH should be 0");
         assertEq(atlas.accountLastActiveBlock(solverOneEOA), 0, "solverOne's last active block should be 0");
         assertEq(atlas.bondedTotalSupply(), 1e18, "total bonded atlETH supply should be 1 ETH");
 
         // unbond should be blocked during metacall
         atlas.setLock(address(solverOneEOA), 0, 0);
         vm.expectRevert(AtlasErrors.InvalidLockState.selector);
-        atlas.unbond(1e18);
+        atlas.requestUncommit(1e18);
         atlas.clearTransientStorage();
 
         // Reverts if unbonding more than bonded balance
         vm.expectRevert(); // Underflow error
-        atlas.unbond(2e18);
+        atlas.requestUncommit(2e18);
 
         vm.expectEmit(true, true, false, true);
-        emit AtlasEvents.Unbond(solverOneEOA, 1e18, block.number + atlas.ESCROW_DURATION() + 1);
-        atlas.unbond(1e18);
+        emit AtlasEvents.UncommitRequested(solverOneEOA, 1e18, block.number + atlas.ESCROW_DURATION() + 1);
+        atlas.requestUncommit(1e18);
 
         // NOTE: On unbonding, individual account bonded balances decrease, but total bonded supply remains the same
         assertEq(atlas.balanceOf(solverOneEOA), 0, "solverOne's atlETH balance should be 0");
-        assertEq(atlas.balanceOfBonded(solverOneEOA), 0, "solverOne's bonded atlETH should be 1 ETH");
-        assertEq(atlas.balanceOfUnbonding(solverOneEOA), 1e18, "solverOne's unbonding atlETH should be 1 ETH");
+        assertEq(atlas.balanceOfCommitted(solverOneEOA), 0, "solverOne's bonded atlETH should be 1 ETH");
+        assertEq(atlas.balanceOfUncommitting(solverOneEOA), 1e18, "solverOne's unbonding atlETH should be 1 ETH");
         assertEq(atlas.accountLastActiveBlock(solverOneEOA), block.number, "solverOne's last active block should be the current block");
         assertEq(atlas.bondedTotalSupply(), 1e18, "total bonded atlETH supply should be 1e18");
     }
 
     function test_atleth_redeem() public {
         vm.startPrank(solverOneEOA);
-        atlas.bond(1e18);
-        atlas.unbond(1e18);
+        atlas.commit(1e18);
+        atlas.requestUncommit(1e18);
 
         uint256 solverEthBefore = address(solverOneEOA).balance;
         uint256 totalSupplyBefore = atlas.totalSupply();
         assertEq(atlas.balanceOf(solverOneEOA), 0, "solverOne's atlETH balance should be 0");
-        assertEq(atlas.balanceOfUnbonding(solverOneEOA), 1e18, "solverOne's unbonding atlETH should be 1 ETH");
+        assertEq(atlas.balanceOfUncommitting(solverOneEOA), 1e18, "solverOne's unbonding atlETH should be 1 ETH");
         assertEq(atlas.bondedTotalSupply(), 1e18, "total bonded atlETH supply should be 1 ETH");
 
         // redeem should be blocked during metacall
         atlas.setLock(address(solverOneEOA), 0, 0);
         vm.expectRevert(AtlasErrors.InvalidLockState.selector);
-        atlas.redeem(1e18);
+        atlas.completeUncommit(1e18);
         atlas.clearTransientStorage();
 
         vm.expectRevert(AtlasErrors.EscrowLockActive.selector);
-        atlas.redeem(1e18);
+        atlas.completeUncommit(1e18);
 
         vm.roll(block.number + atlas.ESCROW_DURATION() + 1);
 
         vm.expectEmit(true, true, false, true);
-        emit AtlasEvents.Redeem(solverOneEOA, 1e18);
-        atlas.redeem(1e18);
+        emit AtlasEvents.UncommitCompleted(solverOneEOA, 1e18);
+        atlas.completeUncommit(1e18);
 
         assertEq(address(solverOneEOA).balance, solverEthBefore, "solverOne's ETH balance should be the same");
         assertEq(atlas.totalSupply(), totalSupplyBefore + 1e18, "total atlETH supply should be 1 ETH more");
         assertEq(atlas.balanceOf(solverOneEOA), 1e18, "solverOne's atlETH balance should be 1 ETH");
-        assertEq(atlas.balanceOfUnbonding(solverOneEOA), 0, "solverOne's unbonding atlETH should be 0");
+        assertEq(atlas.balanceOfUncommitting(solverOneEOA), 0, "solverOne's unbonding atlETH should be 0");
         assertEq(atlas.bondedTotalSupply(), 0, "total bonded atlETH supply should be 0");
     }
 
@@ -206,47 +206,47 @@ contract AtlETHTest is BaseTest {
         assertEq(atlas.balanceOf(userEOA), 1e18, "user's atlETH balance should now be 1 ETH");
     }
 
-    function test_atleth_balanceOfBonded() public {
-        assertEq(atlas.balanceOfBonded(solverOneEOA), 0, "solverOne's bonded atlETH starts at 0");
+    function test_atleth_balanceOfCommitted() public {
+        assertEq(atlas.balanceOfCommitted(solverOneEOA), 0, "solverOne's bonded atlETH starts at 0");
         assertEq(atlas.bondedTotalSupply(), 0, "total bonded atlETH supply should be 0");
 
         vm.prank(solverOneEOA);
-        atlas.bond(1e18);
+        atlas.commit(1e18);
 
-        assertEq(atlas.balanceOfBonded(solverOneEOA), 1e18, "solverOne's bonded atlETH should be 1 ETH");
+        assertEq(atlas.balanceOfCommitted(solverOneEOA), 1e18, "solverOne's bonded atlETH should be 1 ETH");
         assertEq(atlas.bondedTotalSupply(), 1e18, "total bonded atlETH supply should be 1 ETH");
     }
 
-    function test_atleth_balanceOfUnbonding() public {
-        assertEq(atlas.balanceOfUnbonding(solverOneEOA), 0, "solverOne's unbonding atlETH starts at 0");
+    function test_atleth_balanceOfUncommitting() public {
+        assertEq(atlas.balanceOfUncommitting(solverOneEOA), 0, "solverOne's unbonding atlETH starts at 0");
 
         vm.startPrank(solverOneEOA);
-        atlas.bond(1e18);
-        atlas.unbond(1e18);
+        atlas.commit(1e18);
+        atlas.requestUncommit(1e18);
         vm.stopPrank();
 
-        assertEq(atlas.balanceOfUnbonding(solverOneEOA), 1e18, "solverOne's unbonding atlETH should be 1 ETH"); 
+        assertEq(atlas.balanceOfUncommitting(solverOneEOA), 1e18, "solverOne's unbonding atlETH should be 1 ETH"); 
     }
 
     function test_atleth_accountLastActiveBlock() public {
         assertEq(atlas.accountLastActiveBlock(solverOneEOA), 0, "solverOne's last active block should be 0");
 
         vm.startPrank(solverOneEOA);
-        atlas.bond(1e18);
-        atlas.unbond(1e18);
+        atlas.commit(1e18);
+        atlas.requestUncommit(1e18);
         vm.stopPrank();
 
         assertEq(atlas.accountLastActiveBlock(solverOneEOA), block.number, "solverOne's last active block should be the current block");
     }
 
-    function test_atleth_unbondingCompleteBlock() public {
-        assertEq(atlas.unbondingCompleteBlock(solverOneEOA), 0, "solverOne's unbonding complete block should be 0");
+    function test_atleth_uncommitCompleteBlock() public {
+        assertEq(atlas.uncommitCompleteBlock(solverOneEOA), 0, "solverOne's unbonding complete block should be 0");
 
         vm.startPrank(solverOneEOA);
-        atlas.bond(1e18);
-        atlas.unbond(1e18);
+        atlas.commit(1e18);
+        atlas.requestUncommit(1e18);
         vm.stopPrank();
 
-        assertEq(atlas.unbondingCompleteBlock(solverOneEOA), block.number + atlas.ESCROW_DURATION(), "solverOne's unbonding complete block should be the current block + 64");
+        assertEq(atlas.uncommitCompleteBlock(solverOneEOA), block.number + atlas.ESCROW_DURATION(), "solverOne's unbonding complete block should be the current block + 64");
     }
 }

--- a/test/Escrow.t.sol
+++ b/test/Escrow.t.sol
@@ -118,7 +118,7 @@ contract EscrowTest is BaseTest {
 
         vm.startPrank(solverOneEOA);
         dummySolver = new DummySolver(address(atlas));
-        atlas.depositAndBond{ value: 1 ether }(1 ether);
+        atlas.depositAndCommit{ value: 1 ether }(1 ether);
         vm.stopPrank();
 
         deal(address(dummySolver), defaultBidAmount);
@@ -323,7 +323,7 @@ contract EscrowTest is BaseTest {
 
     function test_executeSolverOperation_validateSolverOperation_perBlockLimit_SkipCoverage() public {
         vm.prank(solverOneEOA);
-        atlas.unbond(1); // This will set the solver's lastAccessedBlock to the current block
+        atlas.requestUncommit(1); // This will set the solver's lastAccessedBlock to the current block
 
         (UserOperation memory userOp, SolverOperation[] memory solverOps) = executeSolverOperationInit(defaultCallConfig().build());
         executeSolverOperationCase(userOp, solverOps, false, false, 1 << uint256(SolverOutcome.PerBlockLimit), false);
@@ -334,7 +334,7 @@ contract EscrowTest is BaseTest {
         vm.txGasPrice(10e18); // Set a gas price that will cause the solver to run out of escrow
         uint256 solverGasLimit = 1_000_000;
         uint256 maxSolverGasCost = solverGasLimit * tx.gasprice;
-        assertTrue(maxSolverGasCost > atlas.balanceOfBonded(solverOneEOA), "maxSolverGasCost must be greater than solver bonded AtlETH to trigger InsufficientEscrow");
+        assertTrue(maxSolverGasCost > atlas.balanceOfCommitted(solverOneEOA), "maxSolverGasCost must be greater than solver bonded AtlETH to trigger InsufficientEscrow");
 
         (UserOperation memory userOp, SolverOperation[] memory solverOps) = executeSolverOperationInit(defaultCallConfig().build());
         solverOps[0] = validSolverOperation(userOp)

--- a/test/ExPost.t.sol
+++ b/test/ExPost.t.sol
@@ -95,10 +95,10 @@ contract ExPostTest is BaseTest {
         console.log("solverOneXP  WETH:", WETH.balanceOf(address(solverOneXP)));
 
         vm.prank(address(solverOneEOA));
-        atlas.bond(1 ether);
+        atlas.commit(1 ether);
 
         vm.prank(address(solverTwoEOA));
-        atlas.bond(1 ether);
+        atlas.commit(1 ether);
 
         // First SolverOperation
         solverOpData = helper.buildV2SolverOperationData(POOL_TWO, POOL_ONE);
@@ -317,7 +317,7 @@ contract ExPostTest is BaseTest {
             deal(TOKEN_ONE, address(solverXPs[i]), 10e24);
             vm.startPrank(address(solverEOAs[i]));
             atlas.deposit{ value: 1e18 }();
-            atlas.bond(1 ether);
+            atlas.commit(1 ether);
             vm.stopPrank();
         }
         uint8 v;

--- a/test/FLOnline.t.sol
+++ b/test/FLOnline.t.sol
@@ -1569,14 +1569,14 @@ contract FastLaneOnlineTest is BaseTest {
     {
         vm.startPrank(solverEOA);
         // Make sure solver has 1 AtlETH bonded in Atlas
-        uint256 bonded = atlas.balanceOfBonded(solverEOA);
+        uint256 bonded = atlas.balanceOfCommitted(solverEOA);
         if (bonded < 1e18) {
             uint256 atlETHBalance = atlas.balanceOf(solverEOA);
             if (atlETHBalance < 1e18) {
                 deal(solverEOA, 1e18 - atlETHBalance);
                 atlas.deposit{ value: 1e18 - atlETHBalance }();
             }
-            atlas.bond(1e18 - bonded);
+            atlas.commit(1e18 - bonded);
         }
 
         // Deploy RFQ solver contract

--- a/test/FlashLoan.t.sol
+++ b/test/FlashLoan.t.sol
@@ -54,7 +54,7 @@ contract FlashLoanTest is BaseTest {
         vm.startPrank(solverOneEOA);
         SimpleSolver solver = new SimpleSolver(WETH_ADDRESS, address(atlas));
         deal(WETH_ADDRESS, address(solver), 1e18); // 1 WETH to solver to pay bid
-        atlas.bond(1 ether); // gas for solver to pay
+        atlas.commit(1 ether); // gas for solver to pay
         vm.stopPrank();
 
         vm.startPrank(userEOA);
@@ -228,10 +228,10 @@ contract FlashLoanTest is BaseTest {
 
         userBefore.eth = address(userEOA).balance;
         userBefore.atlETH = atlas.balanceOf(userEOA);
-        userBefore.bonded = atlas.balanceOfBonded(userEOA);
+        userBefore.bonded = atlas.balanceOfCommitted(userEOA);
 
         assertEq(solverStartingTotal, 1e18, "solver incorrect starting WETH");
-        solverStartingTotal += (atlas.balanceOf(solverOneEOA) + atlas.balanceOfBonded(solverOneEOA));
+        solverStartingTotal += (atlas.balanceOf(solverOneEOA) + atlas.balanceOfCommitted(solverOneEOA));
 
         assertEq(atlasStartingETH, 104e18, "atlas incorrect starting ETH"); // 4e from solvers + 100e user deposit
 
@@ -259,14 +259,14 @@ contract FlashLoanTest is BaseTest {
 
         {
             console.log("solverStartingTotal:  ", solverStartingTotal);
-            console.log("solverEndingTotal  :  ", WETH.balanceOf(address(solver)) + atlas.balanceOf(solverOneEOA) + atlas.balanceOfBonded(solverOneEOA));
-            solverStartingTotal -= (WETH.balanceOf(address(solver)) + atlas.balanceOf(solverOneEOA) + atlas.balanceOfBonded(solverOneEOA));
+            console.log("solverEndingTotal  :  ", WETH.balanceOf(address(solver)) + atlas.balanceOf(solverOneEOA) + atlas.balanceOfCommitted(solverOneEOA));
+            solverStartingTotal -= (WETH.balanceOf(address(solver)) + atlas.balanceOf(solverOneEOA) + atlas.balanceOfCommitted(solverOneEOA));
             console.log("solverDeltaTotal   :  ", solverStartingTotal);
         }
 
         userAfter.eth = address(userEOA).balance;
         userAfter.atlETH = atlas.balanceOf(userEOA);
-        userAfter.bonded = atlas.balanceOfBonded(userEOA);
+        userAfter.bonded = atlas.balanceOfCommitted(userEOA);
 
         {
             console.log("userStartingTotal  :", userBefore.eth + userBefore.atlETH + userBefore.bonded);

--- a/test/GasAccounting.t.sol
+++ b/test/GasAccounting.t.sol
@@ -222,7 +222,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         // In reality, the solver's contract calls reconcile()
         address solverContract = makeAddr("SolverContract");
         hoax(solverOneEOA, 1e18);
-        tAtlas.depositAndBond{ value: 1e18 }(1e18); // solver has 1 ETH bonded
+        tAtlas.depositAndCommit{ value: 1e18 }(1e18); // solver has 1 ETH bonded
         tAtlas.setSolverLock(uint256(uint160(solverOneEOA)));
 
         // Solver has a 1M gas liability, and a 1 ETH borrow liability
@@ -379,11 +379,11 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         
         // Setup solver1
         hoax(solverOneEOA, 1e18);
-        tAtlas.depositAndBond{ value: 1e18 }(1e18);
+        tAtlas.depositAndCommit{ value: 1e18 }(1e18);
         
         // Setup solver2
         hoax(solverTwoEOA, 1e18);
-        tAtlas.depositAndBond{ value: 1e18 }(1e18);
+        tAtlas.depositAndCommit{ value: 1e18 }(1e18);
 
         // Set initial solver lock for solver1
         tAtlas.setLock(executionEnvironment, uint32(0), uint8(ExecutionPhase.SolverOperation));
@@ -465,13 +465,13 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
     function test_GasAccounting_assign() public {
         vm.deal(solverOneEOA, 6e18); // 3 to unbonded, 2 unbonding, 1 bonded
         vm.startPrank(solverOneEOA);
-        tAtlas.depositAndBond{ value: 6e18 }(3e18);
+        tAtlas.depositAndCommit{ value: 6e18 }(3e18);
         tAtlas.unbond(2e18);
 
         EscrowAccountAccessData memory accountData = tAtlas.getAccessData(solverOneEOA);
         uint256 unbonded = tAtlas.balanceOf(solverOneEOA);
-        uint256 unbonding = tAtlas.balanceOfUnbonding(solverOneEOA);
-        uint256 bonded = tAtlas.balanceOfBonded(solverOneEOA);
+        uint256 unbonding = tAtlas.balanceOfUncommitting(solverOneEOA);
+        uint256 bonded = tAtlas.balanceOfCommitted(solverOneEOA);
         uint256 bondedTotalSupply = tAtlas.bondedTotalSupply(); // bonded + unbonding included in bondedTotalSupply
         uint32 lastAccessedBlock;
 
@@ -493,8 +493,8 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
 
         (, lastAccessedBlock,,,) = tAtlas.accessData(solverOneEOA);
         assertEq(tAtlas.balanceOf(solverOneEOA), unbonded, "unbonded balance should not change");
-        assertEq(tAtlas.balanceOfUnbonding(solverOneEOA), unbonding, "unbonding balance should not change");
-        assertEq(tAtlas.balanceOfBonded(solverOneEOA), bonded - 1e18, "bonded balance should decrease by 1e18");
+        assertEq(tAtlas.balanceOfUncommitting(solverOneEOA), unbonding, "unbonding balance should not change");
+        assertEq(tAtlas.balanceOfCommitted(solverOneEOA), bonded - 1e18, "bonded balance should decrease by 1e18");
         assertEq(tAtlas.bondedTotalSupply(), bondedTotalSupply - 1e18, "bondedTotalSupply should decrease by 1e18");
         assertEq(lastAccessedBlock, accountData.lastAccessedBlock + 100, "lastAccessedBlock should be updated");
 
@@ -503,8 +503,8 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         tAtlas.assign(accountData, solverOneEOA, 2e18); // should take 1 from bonded, 1 from unbonding
 
         assertEq(tAtlas.balanceOf(solverOneEOA), unbonded, "unbonded balance should not change");
-        assertEq(tAtlas.balanceOfUnbonding(solverOneEOA), unbonding - 1e18, "unbonding balance should decrease by 1e18");
-        assertEq(tAtlas.balanceOfBonded(solverOneEOA), bonded - 1e18, "bonded balance should decrease by 1e18");
+        assertEq(tAtlas.balanceOfUncommitting(solverOneEOA), unbonding - 1e18, "unbonding balance should decrease by 1e18");
+        assertEq(tAtlas.balanceOfCommitted(solverOneEOA), bonded - 1e18, "bonded balance should decrease by 1e18");
         assertEq(tAtlas.bondedTotalSupply(), bondedTotalSupply - 2e18, "bondedTotalSupply should decrease by 2e18");
         assertEq(lastAccessedBlock, accountData.lastAccessedBlock + 100, "lastAccessedBlock should be updated");
 
@@ -514,8 +514,8 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         uint256 deficit = tAtlas.assign(accountData, solverOneEOA, 4e18);
 
         assertEq(tAtlas.balanceOf(solverOneEOA), unbonded, "unbonded balance should not change");
-        assertEq(tAtlas.balanceOfUnbonding(solverOneEOA), 0, "unbonding balance should be 0");
-        assertEq(tAtlas.balanceOfBonded(solverOneEOA), 0, "bonded balance should be 0");
+        assertEq(tAtlas.balanceOfUncommitting(solverOneEOA), 0, "unbonding balance should be 0");
+        assertEq(tAtlas.balanceOfCommitted(solverOneEOA), 0, "bonded balance should be 0");
         assertEq(tAtlas.bondedTotalSupply(), bondedTotalSupply - 3e18, "bondedTotalSupply should decrease by 3e18");
         assertEq(lastAccessedBlock, accountData.lastAccessedBlock + 100, "lastAccessedBlock should be updated");
         assertEq(deficit, expectedDeficit, "deficit should be 1e18");
@@ -551,7 +551,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
 
         vm.deal(solverOneEOA, 2e18); // 1 to unbonded, 1 bonded
         vm.startPrank(solverOneEOA);
-        tAtlas.depositAndBond{ value: 2e18 }(1e18);
+        tAtlas.depositAndCommit{ value: 2e18 }(1e18);
 
         uint256 dConfigSolverGasLimit = 1_000_000;
         vm.txGasPrice(1e9); // set gas price to 1 gwei
@@ -754,20 +754,20 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
 
         // Give solvers bonded atlETH to pay with
         hoax(solverOneEOA, 1e18);
-        tAtlas.depositAndBond{ value: 1e18 }(1e18);
+        tAtlas.depositAndCommit{ value: 1e18 }(1e18);
         hoax(solverTwoEOA, 1e18);
-        tAtlas.depositAndBond{ value: 1e18 }(1e18);
+        tAtlas.depositAndCommit{ value: 1e18 }(1e18);
 
         uint256 snapshot = vm.snapshotState();
 
         hoax(solverThreeEOA, 1e18); // Solver 3 will have no bonded atlETH in Case 4 below.
-        tAtlas.depositAndBond{ value: 1e18 }(1e18);
+        tAtlas.depositAndCommit{ value: 1e18 }(1e18);
 
         // Sum of starting bonded balances should be 3e18
         assertEq(tAtlas.bondedTotalSupply(), 3e18, "C0: bondedTotalSupply should be 3e18");
-        assertEq(tAtlas.balanceOfBonded(solverOneEOA), 1e18, "C0: solverOneEOA bonded balance should start 1e18");
-        assertEq(tAtlas.balanceOfBonded(solverTwoEOA), 1e18, "C0: solverTwoEOA bonded balance should start 1e18");
-        assertEq(tAtlas.balanceOfBonded(solverThreeEOA), 1e18, "C0: solverThreeEOA bonded balance should start 1e18");
+        assertEq(tAtlas.balanceOfCommitted(solverOneEOA), 1e18, "C0: solverOneEOA bonded balance should start 1e18");
+        assertEq(tAtlas.balanceOfCommitted(solverTwoEOA), 1e18, "C0: solverTwoEOA bonded balance should start 1e18");
+        assertEq(tAtlas.balanceOfCommitted(solverThreeEOA), 1e18, "C0: solverThreeEOA bonded balance should start 1e18");
 
         // ===============================
         // Case 1: No unreached solvers -> winning solver idx = 2
@@ -786,9 +786,9 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
 
         assertEq(unreachedCalldataValuePaid, 0, "C1: unreachedCalldataValuePaid should be 0");
         assertEq(tAtlas.bondedTotalSupply(), 3e18, "C1: bondedTotalSupply should be 3e18");
-        assertEq(tAtlas.balanceOfBonded(solverOneEOA), 1e18, "C1: solverOneEOA bonded balance should be 1e18");
-        assertEq(tAtlas.balanceOfBonded(solverTwoEOA), 1e18, "C1: solverTwoEOA bonded balance should be 1e18");
-        assertEq(tAtlas.balanceOfBonded(solverThreeEOA), 1e18, "C1: solverThreeEOA bonded balance should be 1e18");
+        assertEq(tAtlas.balanceOfCommitted(solverOneEOA), 1e18, "C1: solverOneEOA bonded balance should be 1e18");
+        assertEq(tAtlas.balanceOfCommitted(solverTwoEOA), 1e18, "C1: solverTwoEOA bonded balance should be 1e18");
+        assertEq(tAtlas.balanceOfCommitted(solverThreeEOA), 1e18, "C1: solverThreeEOA bonded balance should be 1e18");
         assertApproxEqRel(
             gLAfter.writeoffsGas,
             constGas, // no loops, just constant gas
@@ -801,7 +801,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         // ===============================
         vm.revertToState(snapshot);
         hoax(solverThreeEOA, 1e18); // solver 3 has bonded atlETH in this case
-        tAtlas.depositAndBond{ value: 1e18 }(1e18);
+        tAtlas.depositAndCommit{ value: 1e18 }(1e18);
 
         unreachedCalldataValuePaid = tAtlas.chargeUnreachedSolversForCalldata({
             solverOps: solverOps, 
@@ -825,10 +825,10 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
             3e18 - solverOpCalldataGasValue,
             "C2: bondedTotalSupply should be 3e18 - solverOpCalldataGasValue"
         );
-        assertEq(tAtlas.balanceOfBonded(solverOneEOA), 1e18, "C2: solverOneEOA bonded balance should be 1e18");
-        assertEq(tAtlas.balanceOfBonded(solverTwoEOA), 1e18, "C2: solverTwoEOA bonded balance should be 1e18");
+        assertEq(tAtlas.balanceOfCommitted(solverOneEOA), 1e18, "C2: solverOneEOA bonded balance should be 1e18");
+        assertEq(tAtlas.balanceOfCommitted(solverTwoEOA), 1e18, "C2: solverTwoEOA bonded balance should be 1e18");
         assertEq(
-            tAtlas.balanceOfBonded(solverThreeEOA),
+            tAtlas.balanceOfCommitted(solverThreeEOA),
             1e18 - solverOpCalldataGasValue,
             "C2: solverThreeEOA bonded balance should be 1e18 - solverOpCalldataGasValue"
         );
@@ -844,7 +844,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         // ===============================
         vm.revertToState(snapshot);
         hoax(solverThreeEOA, 1e18); // solver 3 has bonded atlETH in this case
-        tAtlas.depositAndBond{ value: 1e18 }(1e18);
+        tAtlas.depositAndCommit{ value: 1e18 }(1e18);
 
         unreachedCalldataValuePaid = tAtlas.chargeUnreachedSolversForCalldata({
             solverOps: solverOps, 
@@ -868,14 +868,14 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
             3e18 - (2 * solverOpCalldataGasValue),
             "C3: bondedTotalSupply should be 3e18 - 2 * solverOpCalldataGasValue"
         );
-        assertEq(tAtlas.balanceOfBonded(solverOneEOA), 1e18, "C3: solverOneEOA bonded balance should be 1e18");
+        assertEq(tAtlas.balanceOfCommitted(solverOneEOA), 1e18, "C3: solverOneEOA bonded balance should be 1e18");
         assertEq(
-            tAtlas.balanceOfBonded(solverTwoEOA),
+            tAtlas.balanceOfCommitted(solverTwoEOA),
             1e18 - solverOpCalldataGasValue,
             "C3: solverTwoEOA bonded balance should be 1e18 - solverOpCalldataGasValue"
         );
         assertEq(
-            tAtlas.balanceOfBonded(solverThreeEOA),
+            tAtlas.balanceOfCommitted(solverThreeEOA),
             1e18 - solverOpCalldataGasValue,
             "C3: solverThreeEOA bonded balance should be 1e18 - solverOpCalldataGasValue"
         );
@@ -916,14 +916,14 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
             2e18 - solverOpCalldataGasValue,
             "C4: bondedTotalSupply should be 2e18 - 1x solverOpCalldataGasValue"
         );
-        assertEq(tAtlas.balanceOfBonded(solverOneEOA), 1e18, "C4: solverOneEOA bonded balance should be 1e18");
+        assertEq(tAtlas.balanceOfCommitted(solverOneEOA), 1e18, "C4: solverOneEOA bonded balance should be 1e18");
         assertEq(
-            tAtlas.balanceOfBonded(solverTwoEOA),
+            tAtlas.balanceOfCommitted(solverTwoEOA),
             1e18 - solverOpCalldataGasValue,
             "C4: solverTwoEOA bonded balance should be 1e18 - solverOpCalldataGasValue"
         );
         assertEq(
-            tAtlas.balanceOfBonded(solverThreeEOA),
+            tAtlas.balanceOfCommitted(solverThreeEOA),
             0, // Because solver 3 has no bonded atlETH at start of this test case
             "C4: solverThreeEOA bonded balance should be 0"
         );
@@ -940,7 +940,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
 
         vm.revertToState(snapshot);
         hoax(solverThreeEOA, 1e18); // solver 3 has bonded atlETH in this case
-        tAtlas.depositAndBond{ value: 1e18 }(1e18);
+        tAtlas.depositAndCommit{ value: 1e18 }(1e18);
 
         // Set last 2 solvers to bundler fault (missing solver signature)
         solverOps[1].signature = "";
@@ -968,9 +968,9 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
             3e18,
             "C5: bondedTotalSupply should be 3e18"
         );
-        assertEq(tAtlas.balanceOfBonded(solverOneEOA), 1e18, "C5: solverOne bonded should not change");
-        assertEq(tAtlas.balanceOfBonded(solverTwoEOA), 1e18, "C5: solverTwo bonded should not change");
-        assertEq(tAtlas.balanceOfBonded(solverThreeEOA), 1e18, "C5: solverThree bonded should not change");
+        assertEq(tAtlas.balanceOfCommitted(solverOneEOA), 1e18, "C5: solverOne bonded should not change");
+        assertEq(tAtlas.balanceOfCommitted(solverTwoEOA), 1e18, "C5: solverTwo bonded should not change");
+        assertEq(tAtlas.balanceOfCommitted(solverThreeEOA), 1e18, "C5: solverThree bonded should not change");
         assertApproxEqRel(
             gLAfter.writeoffsGas,
             // 2 bundler fault iterations + constant gas + 2x calldata gas
@@ -1025,7 +1025,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
 
         vm.deal(address(tAtlas), 1e18); // Give Atlas ETH as if paid from failed/unreached solvers
         hoax(solverOneEOA, 1e18); // Give winning solver 1 bonded atlETH
-        tAtlas.depositAndBond{ value: 1e18 }(1e18);
+        tAtlas.depositAndCommit{ value: 1e18 }(1e18);
         EscrowAccountAccessData memory aDataBefore = tAtlas.getAccessData(solverOneEOA);
         uint256 bundlerBalanceBefore = userEOA.balance;
         uint256 atlasSurchargeBefore = tAtlas.cumulativeSurcharge();
@@ -1054,7 +1054,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         EscrowAccountAccessData memory aDataAfter = tAtlas.getAccessData(solverOneEOA);
 
         assertApproxEqRel(
-            tAtlas.balanceOfBonded(solverOneEOA),
+            tAtlas.balanceOfCommitted(solverOneEOA),
             1e18 - estWinningSolverCharge,
             0.01e18, // 1% tolerance
             "C3: winning solver bonded balance should decrease by estWinningSolverCharge"
@@ -1108,7 +1108,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         aDataAfter = tAtlas.getAccessData(solverOneEOA);
 
         // solverOne is not winner - no charge or change in analytics expected
-        assertEq(tAtlas.balanceOfBonded(solverOneEOA), 1e18, "C4: solverOne is not winner - no balance change");
+        assertEq(tAtlas.balanceOfCommitted(solverOneEOA), 1e18, "C4: solverOne is not winner - no balance change");
         assertEq(aDataAfter.auctionWins, aDataBefore.auctionWins, "C4: auctionWins should not change");
         assertEq(aDataAfter.auctionFails, aDataBefore.auctionFails, "C4: auctionFails should not change");
         assertEq(aDataAfter.totalGasValueUsed, aDataBefore.totalGasValueUsed, "C4: totalGasValueUsed should not change");
@@ -1155,7 +1155,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         aDataAfter = tAtlas.getAccessData(solverOneEOA);
 
         // solverOne is not winner - no charge or change in analytics expected
-        assertEq(tAtlas.balanceOfBonded(solverOneEOA), 1e18, "solverOne is not winner - no balance change");
+        assertEq(tAtlas.balanceOfCommitted(solverOneEOA), 1e18, "solverOne is not winner - no balance change");
         assertEq(aDataAfter.auctionWins, aDataBefore.auctionWins, "auctionWins should not change");
         assertEq(aDataAfter.auctionFails, aDataBefore.auctionFails, "auctionFails should not change");
         assertEq(aDataAfter.totalGasValueUsed, aDataBefore.totalGasValueUsed, "totalGasValueUsed should not change");

--- a/test/MainTest.t.sol
+++ b/test/MainTest.t.sol
@@ -96,10 +96,10 @@ contract MainTest is BaseTest {
         console.log("solverOne    WETH:", WETH.balanceOf(address(solverOne)));
 
         vm.prank(address(solverOneEOA));
-        atlas.bond(1 ether);
+        atlas.commit(1 ether);
 
         vm.prank(address(solverTwoEOA));
-        atlas.bond(1 ether);
+        atlas.commit(1 ether);
 
         // First SolverOperation
         solverOpData = helper.buildV2SolverOperationData(POOL_TWO, POOL_ONE);
@@ -384,7 +384,7 @@ contract MainTest is BaseTest {
         bytes32 s;
 
         vm.prank(solverOneEOA);
-        atlas.bond(1 ether);
+        atlas.commit(1 ether);
 
         UserOperation memory userOp = helper.buildUserOperation(POOL_ONE, POOL_TWO, userEOA, TOKEN_ONE);
         // User does not sign their own operation when bundling
@@ -455,10 +455,10 @@ contract MainTest is BaseTest {
         // Success case
 
         vm.prank(address(solverOneEOA));
-        atlas.bond(1 ether);
+        atlas.commit(1 ether);
 
         vm.prank(address(solverTwoEOA));
-        atlas.bond(1 ether);
+        atlas.commit(1 ether);
 
         bytes memory solverOpData = helper.buildV2SolverOperationData(POOL_TWO, POOL_ONE);
         solverOps[0] = helper.buildSolverOperation(userOp, solverOpData, solverOneEOA, address(solverOne), 2e17, 0);
@@ -508,7 +508,7 @@ contract MainTest is BaseTest {
         address beneficiary = makeAddr("beneficiary");
 
         vm.prank(solverOneEOA);
-        atlas.bond(1 ether);
+        atlas.commit(1 ether);
 
         UserOperation memory userOp = helper.buildUserOperation(POOL_ONE, POOL_TWO, userEOA, TOKEN_ONE);
         // User does not sign their own operation when bundling
@@ -524,7 +524,7 @@ contract MainTest is BaseTest {
         dAppOp.signature = abi.encodePacked(r, s, v);
         uint256 gasLim = _gasLim(userOp, solverOps);
 
-        uint256 bondedBalanceBefore = atlas.balanceOfBonded(beneficiary);
+        uint256 bondedBalanceBefore = atlas.balanceOfCommitted(beneficiary);
 
         console.log("Beneficiary's balance before metacall", beneficiary.balance);
         console.log("Beneficiary's AtlETH bonded balance before metacall", bondedBalanceBefore);
@@ -537,7 +537,7 @@ contract MainTest is BaseTest {
         atlas.metacall{gas: gasLim}(userOp, solverOps, dAppOp, beneficiary);
         vm.stopPrank();
 
-        uint256 bondedBalanceAfter = atlas.balanceOfBonded(beneficiary);
+        uint256 bondedBalanceAfter = atlas.balanceOfCommitted(beneficiary);
 
         console.log("Beneficiary's balance after metacall", beneficiary.balance);
         console.log("Beneficiary's AtlETH bonded balance after metacall", bondedBalanceAfter);
@@ -561,7 +561,7 @@ contract MainTest is BaseTest {
     //     address beneficiary = makeAddr("beneficiary");
 
     //     vm.prank(solverOneEOA);
-    //     atlas.bond(1 ether);
+    //     atlas.commit(1 ether);
 
     //     UserOperation memory userOp = helper.buildUserOperation(POOL_ONE, POOL_TWO, userEOA, TOKEN_ONE);
     //     // User does not sign their own operation when bundling
@@ -577,7 +577,7 @@ contract MainTest is BaseTest {
     //     dAppOp.signature = abi.encodePacked(r, s, v);
     //     uint256 gasLim = _gasLim(userOp, solverOps);
 
-    //     uint256 bondedBalanceBefore = atlas.balanceOfBonded(beneficiary);
+    //     uint256 bondedBalanceBefore = atlas.balanceOfCommitted(beneficiary);
 
     //     console.log("Beneficiary's balance before metacall", beneficiary.balance);
     //     console.log("Beneficiary's AtlETH bonded balance before metacall", bondedBalanceBefore);
@@ -590,7 +590,7 @@ contract MainTest is BaseTest {
     //     atlas.metacall{gas: gasLim}(userOp, solverOps, dAppOp, beneficiary);
     //     vm.stopPrank();
 
-    //     uint256 bondedBalanceAfter = atlas.balanceOfBonded(beneficiary);
+    //     uint256 bondedBalanceAfter = atlas.balanceOfCommitted(beneficiary);
     //     console.log("Beneficiary's balance after metacall", beneficiary.balance);
     //     console.log("Beneficiary's AtlETH bonded balance after metacall", bondedBalanceAfter);
 

--- a/test/MultipleSolversFourTest.t.sol
+++ b/test/MultipleSolversFourTest.t.sol
@@ -56,28 +56,28 @@ contract MultipleSolversFourTest is BaseTest, AtlasErrors {
             address(WETH_ADDRESS), address(atlas));
         vm.deal(address(solver1), 10 * solverBidAmount);
         vm.prank(solverOneEOA);
-        atlas.depositAndBond{value: 5 ether}(5 ether);
+        atlas.depositAndCommit{value: 5 ether}(5 ether);
 
         vm.prank(solverTwoEOA);
         solver2 = new MockSolver(
             address(WETH_ADDRESS), address(atlas));
         vm.deal(address(solver2), 10 * solverBidAmount);
         vm.prank(solverTwoEOA);
-        atlas.depositAndBond{value: 5 ether}(5 ether);
+        atlas.depositAndCommit{value: 5 ether}(5 ether);
 
         vm.prank(solverThreeEOA);
         solver3 = new MockSolver(
             address(WETH_ADDRESS), address(atlas));
         vm.deal(address(solver3), 10 * solverBidAmount);
         vm.prank(solverThreeEOA);
-        atlas.depositAndBond{value: 5 ether}(5 ether);
+        atlas.depositAndCommit{value: 5 ether}(5 ether);
 
         vm.prank(solverFourEOA);
         solver4 = new MockSolver(
             address(WETH_ADDRESS), address(atlas));
         vm.deal(address(solver4), 10 * solverBidAmount);
         vm.prank(solverFourEOA);
-        atlas.depositAndBond{value: 5 ether}(5 ether);
+        atlas.depositAndCommit{value: 5 ether}(5 ether);
     }
 
     function buildUserOperation(uint256 signerPK) internal view returns (UserOperation memory) {
@@ -462,10 +462,10 @@ contract MultipleSolversFourTest is BaseTest, AtlasErrors {
         uint256 bundlerBalanceBefore = address(bundler).balance;
 
         // Track initial balances
-        uint256 solver1InitialBalance = atlas.balanceOfBonded(address(solverOneEOA));
-        uint256 solver2InitialBalance = atlas.balanceOfBonded(address(solverTwoEOA));
-        uint256 solver3InitialBalance = atlas.balanceOfBonded(address(solverThreeEOA));
-        uint256 solver4InitialBalance = atlas.balanceOfBonded(address(solverFourEOA));
+        uint256 solver1InitialBalance = atlas.balanceOfCommitted(address(solverOneEOA));
+        uint256 solver2InitialBalance = atlas.balanceOfCommitted(address(solverTwoEOA));
+        uint256 solver3InitialBalance = atlas.balanceOfCommitted(address(solverThreeEOA));
+        uint256 solver4InitialBalance = atlas.balanceOfCommitted(address(solverFourEOA));
 
         vm.prank(bundler);
         bool auctionWon = atlas.metacall{gas: metacallGasLimit}(userOp, solverOps, dappOp, address(0));
@@ -483,10 +483,10 @@ contract MultipleSolversFourTest is BaseTest, AtlasErrors {
         assertEq(solver4.counter(), (!solver4BidPattern.isReverting && !solver4BidPattern.isRevertingBundlerFault) ? 1 : 0, "solver4 counter should be 1 if not reverted");
 
         // Track final bonded balances and calculate gas payments
-        uint256 solver1FinalBalance = atlas.balanceOfBonded(address(solverOneEOA));
-        uint256 solver2FinalBalance = atlas.balanceOfBonded(address(solverTwoEOA));
-        uint256 solver3FinalBalance = atlas.balanceOfBonded(address(solverThreeEOA));
-        uint256 solver4FinalBalance = atlas.balanceOfBonded(address(solverFourEOA));
+        uint256 solver1FinalBalance = atlas.balanceOfCommitted(address(solverOneEOA));
+        uint256 solver2FinalBalance = atlas.balanceOfCommitted(address(solverTwoEOA));
+        uint256 solver3FinalBalance = atlas.balanceOfCommitted(address(solverThreeEOA));
+        uint256 solver4FinalBalance = atlas.balanceOfCommitted(address(solverFourEOA));
 
         uint256 solver1GasPayment = solver1InitialBalance - solver1FinalBalance;
         uint256 solver2GasPayment = solver2InitialBalance - solver2FinalBalance;

--- a/test/MultipleSolversLockStateTest.t.sol
+++ b/test/MultipleSolversLockStateTest.t.sol
@@ -46,13 +46,13 @@ contract MultipleSolversLockStateTest is BaseTest, AtlasErrors, AtlasConstants {
         solver1 = new MockSolver(address(WETH_ADDRESS), address(atlas));
         vm.deal(address(solver1), 10 * solverBidAmount);
         vm.prank(solverOneEOA);
-        atlas.depositAndBond{value: 5 ether}(5 ether);
+        atlas.depositAndCommit{value: 5 ether}(5 ether);
 
         vm.prank(solverTwoEOA);
         solver2 = new MockSolver(address(WETH_ADDRESS), address(atlas));
         vm.deal(address(solver2), 10 * solverBidAmount);
         vm.prank(solverTwoEOA);
-        atlas.depositAndBond{value: 5 ether}(5 ether);
+        atlas.depositAndCommit{value: 5 ether}(5 ether);
     }
 
     // Helper function to convert uint256 to binary string, focusing on relevant bits

--- a/test/MultipleSolversTest.t.sol
+++ b/test/MultipleSolversTest.t.sol
@@ -50,14 +50,14 @@ contract MultipleSolversTest is BaseTest, AtlasErrors {
             address(WETH_ADDRESS), address(atlas));
         vm.deal(address(solver1), 10 * solverBidAmount);
         vm.prank(solverOneEOA);
-        atlas.depositAndBond{value: 5 ether}(5 ether);
+        atlas.depositAndCommit{value: 5 ether}(5 ether);
 
         vm.prank(solverTwoEOA);
         solver2 = new MockSolver(
             address(WETH_ADDRESS), address(atlas));
         vm.deal(address(solver2), 10 * solverBidAmount);
         vm.prank(solverTwoEOA);
-        atlas.depositAndBond{value: 5 ether}(5 ether);
+        atlas.depositAndCommit{value: 5 ether}(5 ether);
     }
 
     function buildUserOperation(uint256 signerPK) internal view returns (UserOperation memory) {

--- a/test/OEV.t.sol
+++ b/test/OEV.t.sol
@@ -111,7 +111,7 @@ contract OEVTest is BaseTest {
         vm.startPrank(solverOneEOA);
         LiquidationOEVSolver liquidationSolver = new LiquidationOEVSolver(WETH_ADDRESS, address(atlas));
         atlas.deposit{ value: 1e18 }();
-        atlas.bond(1e18);
+        atlas.commit(1e18);
         vm.stopPrank();
 
         assertTrue(chainlinkDAppControl.isChainlinkWrapper(address(chainlinkAtlasWrapper)), "Wrapper should be registered on DAppControl - otherwise will revert in allocateValue");

--- a/test/OEValt.t.sol
+++ b/test/OEValt.t.sol
@@ -115,7 +115,7 @@ contract OEVTest is BaseTest {
         vm.startPrank(solverOneEOA);
         LiquidationOEVSolver liquidationSolver = new LiquidationOEVSolver(WETH_ADDRESS, address(atlas));
         atlas.deposit{ value: 1e18 }();
-        atlas.bond(1e18);
+        atlas.commit(1e18);
         vm.stopPrank();
 
         (bytes memory report, bytes32[] memory rs, bytes32[] memory ss, bytes32 rawVs)

--- a/test/Simulator.t.sol
+++ b/test/Simulator.t.sol
@@ -313,7 +313,7 @@ contract SimulatorTest is BaseTest {
     function test_simSolverCall_success_validSolverOutcome_SkipCoverage() public {
         vm.startPrank(solverOneEOA);
         DummySolver solver = new DummySolver(WETH_ADDRESS, address(atlas));
-        atlas.bond(1e18);
+        atlas.commit(1e18);
         vm.stopPrank();
 
         UserOperation memory userOp = validUserOperation().build();
@@ -335,7 +335,7 @@ contract SimulatorTest is BaseTest {
     function test_simSolverCall_success_validSolverOutcome_UserOpValue_SkipCoverage() public {
         vm.startPrank(solverOneEOA);
         DummySolver solver = new DummySolver(WETH_ADDRESS, address(atlas));
-        atlas.bond(1e18);
+        atlas.commit(1e18);
         vm.stopPrank();
 
         UserOperation memory userOp = validUserOperation()
@@ -359,7 +359,7 @@ contract SimulatorTest is BaseTest {
     function test_simSolverCall_fail_bubblesUpSolverOutcomeResult_SkipCoverage() public {
         vm.startPrank(solverOneEOA);
         DummySolver solver = new DummySolver(WETH_ADDRESS, address(atlas));
-        // atlas.bond(1e18); - DO NOT BOND - Triggers InsufficientEscrow error
+        // atlas.commit(1e18); - DO NOT BOND - Triggers InsufficientEscrow error
         vm.stopPrank();
 
         
@@ -382,7 +382,7 @@ contract SimulatorTest is BaseTest {
     function test_simSolverCalls_success_validSolverOutcome_SkipCoverage() public {
         vm.startPrank(solverOneEOA);
         DummySolver solver = new DummySolver(WETH_ADDRESS, address(atlas));
-        atlas.bond(1e18);
+        atlas.commit(1e18);
         vm.stopPrank();
 
         UserOperation memory userOp = validUserOperation().build();
@@ -404,7 +404,7 @@ contract SimulatorTest is BaseTest {
     function test_simSolverCalls_success_validSolverOutcome_UserOpValue_SkipCoverage() public {
         vm.startPrank(solverOneEOA);
         DummySolver solver = new DummySolver(WETH_ADDRESS, address(atlas));
-        atlas.bond(1e18);
+        atlas.commit(1e18);
         vm.stopPrank();
 
         UserOperation memory userOp = validUserOperation()
@@ -441,7 +441,7 @@ contract SimulatorTest is BaseTest {
     function test_simSolverCalls_fail_bubblesUpSolverOutcomeResult_SkipCoverage() public {
         vm.startPrank(solverOneEOA);
         DummySolver solver = new DummySolver(WETH_ADDRESS, address(atlas));
-        // atlas.bond(1e18); - DO NOT BOND - Triggers InsufficientEscrow error
+        // atlas.commit(1e18); - DO NOT BOND - Triggers InsufficientEscrow error
         vm.stopPrank();
 
         UserOperation memory userOp = validUserOperation().build();

--- a/test/Sorter.t.sol
+++ b/test/Sorter.t.sol
@@ -107,7 +107,7 @@ contract SorterTest is BaseTest {
 
     function test_sorter_singleOpValid() public {
         SolverOperation[] memory solverOps = new SolverOperation[](1);
-        solverOps[0] = validSolverOperation(solverOnePK, 10).depositAndBondAtlEth(address(atlas), atlEthToBond).build();
+        solverOps[0] = validSolverOperation(solverOnePK, 10).depositAndCommitAtlEth(address(atlas), atlEthToBond).build();
 
         SolverOperation[] memory sortedOps = sorter.sortBids(userOp, solverOps);
         validateSortedOps(sortedOps, 1);
@@ -115,12 +115,12 @@ contract SorterTest is BaseTest {
 
     function test_sorter_allOpsValid_evenNumber() public {
         SolverOperation[] memory solverOps = new SolverOperation[](6);
-        solverOps[0] = validSolverOperation(solverOnePK, 190).depositAndBondAtlEth(address(atlas), atlEthToBond).build();
-        solverOps[1] = validSolverOperation(solverTwoPK, 130).depositAndBondAtlEth(address(atlas), atlEthToBond).build();
-        solverOps[2] = validSolverOperation(solverThreePK, 110).depositAndBondAtlEth(address(atlas), atlEthToBond).build();
-        solverOps[3] = validSolverOperation(solverFourPK, 150).depositAndBondAtlEth(address(atlas), atlEthToBond).build();
-        solverOps[4] = validSolverOperation(solverFivePK, 140).depositAndBondAtlEth(address(atlas), atlEthToBond).build();
-        solverOps[5] = validSolverOperation(solverSixPK, 180).depositAndBondAtlEth(address(atlas), atlEthToBond).build();
+        solverOps[0] = validSolverOperation(solverOnePK, 190).depositAndCommitAtlEth(address(atlas), atlEthToBond).build();
+        solverOps[1] = validSolverOperation(solverTwoPK, 130).depositAndCommitAtlEth(address(atlas), atlEthToBond).build();
+        solverOps[2] = validSolverOperation(solverThreePK, 110).depositAndCommitAtlEth(address(atlas), atlEthToBond).build();
+        solverOps[3] = validSolverOperation(solverFourPK, 150).depositAndCommitAtlEth(address(atlas), atlEthToBond).build();
+        solverOps[4] = validSolverOperation(solverFivePK, 140).depositAndCommitAtlEth(address(atlas), atlEthToBond).build();
+        solverOps[5] = validSolverOperation(solverSixPK, 180).depositAndCommitAtlEth(address(atlas), atlEthToBond).build();
 
         SolverOperation[] memory sortedOps = sorter.sortBids(userOp, solverOps);
         validateSortedOps(sortedOps, 6);
@@ -128,13 +128,13 @@ contract SorterTest is BaseTest {
 
     function test_sorter_allOpsValid_OddNumber() public {
         SolverOperation[] memory solverOps = new SolverOperation[](7);
-        solverOps[0] = validSolverOperation(solverOnePK, 200).depositAndBondAtlEth(address(atlas), atlEthToBond).build();
-        solverOps[1] = validSolverOperation(solverTwoPK, 250).depositAndBondAtlEth(address(atlas), atlEthToBond).build();
-        solverOps[2] = validSolverOperation(solverThreePK, 210).depositAndBondAtlEth(address(atlas), atlEthToBond).build();
-        solverOps[3] = validSolverOperation(solverFourPK, 220).depositAndBondAtlEth(address(atlas), atlEthToBond).build();
-        solverOps[4] = validSolverOperation(solverFivePK, 270).depositAndBondAtlEth(address(atlas), atlEthToBond).build();
-        solverOps[5] = validSolverOperation(solverSixPK, 280).depositAndBondAtlEth(address(atlas), atlEthToBond).build();
-        solverOps[6] = validSolverOperation(solverSevenPK, 230).depositAndBondAtlEth(address(atlas), atlEthToBond).build();
+        solverOps[0] = validSolverOperation(solverOnePK, 200).depositAndCommitAtlEth(address(atlas), atlEthToBond).build();
+        solverOps[1] = validSolverOperation(solverTwoPK, 250).depositAndCommitAtlEth(address(atlas), atlEthToBond).build();
+        solverOps[2] = validSolverOperation(solverThreePK, 210).depositAndCommitAtlEth(address(atlas), atlEthToBond).build();
+        solverOps[3] = validSolverOperation(solverFourPK, 220).depositAndCommitAtlEth(address(atlas), atlEthToBond).build();
+        solverOps[4] = validSolverOperation(solverFivePK, 270).depositAndCommitAtlEth(address(atlas), atlEthToBond).build();
+        solverOps[5] = validSolverOperation(solverSixPK, 280).depositAndCommitAtlEth(address(atlas), atlEthToBond).build();
+        solverOps[6] = validSolverOperation(solverSevenPK, 230).depositAndCommitAtlEth(address(atlas), atlEthToBond).build();
 
         SolverOperation[] memory sortedOps = sorter.sortBids(userOp, solverOps);
         validateSortedOps(sortedOps, 7);
@@ -142,12 +142,12 @@ contract SorterTest is BaseTest {
 
     function test_sorter_mixedOpsValidity_1() public {
         SolverOperation[] memory solverOps = new SolverOperation[](7);
-        solverOps[0] = validSolverOperation(solverOnePK, 310).depositAndBondAtlEth(address(atlas), atlEthToBond).build();
+        solverOps[0] = validSolverOperation(solverOnePK, 310).depositAndCommitAtlEth(address(atlas), atlEthToBond).build();
         solverOps[1] = validSolverOperation(solverTwoPK, 350).build(); // No AtlEth bonded
-        solverOps[2] = validSolverOperation(solverThreePK, 380).depositAndBondAtlEth(address(atlas), atlEthToBond).build();
+        solverOps[2] = validSolverOperation(solverThreePK, 380).depositAndCommitAtlEth(address(atlas), atlEthToBond).build();
         solverOps[3] = validSolverOperation(solverFourPK, 300).build(); // No AtlEth bonded
-        solverOps[4] = validSolverOperation(solverFivePK, 340).depositAndBondAtlEth(address(atlas), atlEthToBond).build();
-        solverOps[5] = validSolverOperation(solverSixPK, 390).depositAndBondAtlEth(address(atlas), atlEthToBond).build();
+        solverOps[4] = validSolverOperation(solverFivePK, 340).depositAndCommitAtlEth(address(atlas), atlEthToBond).build();
+        solverOps[5] = validSolverOperation(solverSixPK, 390).depositAndCommitAtlEth(address(atlas), atlEthToBond).build();
         solverOps[6] = validSolverOperation(solverSevenPK, 320).build(); // No AtlEth bonded
 
         SolverOperation[] memory sortedOps = sorter.sortBids(userOp, solverOps);
@@ -157,33 +157,33 @@ contract SorterTest is BaseTest {
     function test_sorter_mixedOpsValidity_2() public {
         SolverOperation[] memory solverOps = new SolverOperation[](7);
         solverOps[0] = validSolverOperation(solverOnePK, 450)
-            .depositAndBondAtlEth(address(atlas), atlEthToBond)
+            .depositAndCommitAtlEth(address(atlas), atlEthToBond)
             .withUserOpHash("invalid") // Invalid userOpHash
             .signAndBuild(address(atlasVerification), solverOnePK);
 
         solverOps[1] = validSolverOperation(solverTwoPK, 480).build(); // No AtlEth bonded
 
         // This is the only valid solverOp
-        solverOps[2] = validSolverOperation(solverThreePK, 420).depositAndBondAtlEth(address(atlas), atlEthToBond).build();
+        solverOps[2] = validSolverOperation(solverThreePK, 420).depositAndCommitAtlEth(address(atlas), atlEthToBond).build();
 
         solverOps[3] = validSolverOperation(solverFourPK, 410)
-            .depositAndBondAtlEth(address(atlas), atlEthToBond)
+            .depositAndCommitAtlEth(address(atlas), atlEthToBond)
             .withBidToken(address(1)) // Invalid bidToken
             .signAndBuild(address(atlasVerification), solverFourPK);
 
         vm.startPrank(solverFiveEOA);
-        atlas.depositAndBond{value: atlEthToBond}(atlEthToBond);
-        atlas.unbond(1); // This will set the solver's lastAccessedBlock to the current block
+        atlas.depositAndCommit{value: atlEthToBond}(atlEthToBond);
+        atlas.requestUncommit(1); // This will set the solver's lastAccessedBlock to the current block
         vm.stopPrank();
         solverOps[4] = validSolverOperation(solverFivePK, 490).build();
 
         solverOps[5] = validSolverOperation(solverSixPK, 440)
-            .depositAndBondAtlEth(address(atlas), atlEthToBond)
+            .depositAndCommitAtlEth(address(atlas), atlEthToBond)
             .withControl(address(0)) // Invalid dAppControl
             .signAndBuild(address(atlasVerification), solverSixPK);
 
         solverOps[6] = validSolverOperation(solverSevenPK, 460)
-            .depositAndBondAtlEth(address(atlas), atlEthToBond)
+            .depositAndCommitAtlEth(address(atlas), atlEthToBond)
             .withMaxFeePerGas(userOp.maxFeePerGas - 1) // Invalid maxFeePerGas
             .signAndBuild(address(atlasVerification), solverSevenPK);
 

--- a/test/Storage.t.sol
+++ b/test/Storage.t.sol
@@ -51,7 +51,7 @@ contract StorageTest is BaseTest {
 
         vm.deal(userEOA, depositAmount);
         vm.prank(userEOA);
-        atlas.depositAndBond{ value: depositAmount }(depositAmount);
+        atlas.depositAndCommit{ value: depositAmount }(depositAmount);
 
         assertEq(atlas.bondedTotalSupply(), depositAmount, "bondedTotalSupply did not increase correctly");
     }
@@ -74,7 +74,7 @@ contract StorageTest is BaseTest {
 
         vm.deal(userEOA, depositAmount);
         vm.prank(userEOA);
-        atlas.depositAndBond{ value: depositAmount }(depositAmount);
+        atlas.depositAndCommit{ value: depositAmount }(depositAmount);
 
         (bonded, lastAccessedBlock, auctionWins, auctionFails, totalGasValueUsed) = atlas.accessData(userEOA);
 
@@ -85,7 +85,7 @@ contract StorageTest is BaseTest {
         assertEq(totalGasValueUsed, 0, "user totalGasValueUsed should still be 0");
 
         vm.prank(userEOA);
-        atlas.unbond(depositAmount);
+        atlas.requestUncommit(depositAmount);
 
         (bonded, lastAccessedBlock, auctionWins, auctionFails, totalGasValueUsed) = atlas.accessData(userEOA);
 

--- a/test/SwapIntent.t.sol
+++ b/test/SwapIntent.t.sol
@@ -78,7 +78,7 @@ contract SwapIntentTest is BaseTest {
         vm.startPrank(solverOneEOA);
         SimpleRFQSolver rfqSolver = new SimpleRFQSolver(WETH_ADDRESS, address(atlas));
         atlas.deposit{ value: 1e18 }();
-        atlas.bond(1 ether);
+        atlas.commit(1 ether);
         vm.stopPrank();
 
         // Give 20 DAI to RFQ solver contract
@@ -208,7 +208,7 @@ contract SwapIntentTest is BaseTest {
         UniswapIntentSolver uniswapSolver = new UniswapIntentSolver(WETH_ADDRESS, address(atlas));
         deal(WETH_ADDRESS, address(uniswapSolver), 1e18); // 1 WETH to solver to pay bid
         atlas.deposit{ value: 1e18 }();
-        atlas.bond(1 ether);
+        atlas.commit(1 ether);
         vm.stopPrank();
 
         // Input params for Atlas.metacall() - will be populated below

--- a/test/SwapIntentInvertBid.t.sol
+++ b/test/SwapIntentInvertBid.t.sol
@@ -179,7 +179,7 @@ contract SwapIntentTest is BaseTest {
         SimpleRFQSolverInvertBid rfqSolver =
             new SimpleRFQSolverInvertBid(WETH_ADDRESS, address(atlas), solverBidRetreivalRequired);
         atlas.deposit{ value: 1e18 }();
-        atlas.bond(1 ether);
+        atlas.commit(1 ether);
         vm.stopPrank();
 
         deal(DAI_ADDRESS, address(rfqSolver), swapIntent.amountUserBuys);

--- a/test/TrebleSwap.t.sol
+++ b/test/TrebleSwap.t.sol
@@ -455,14 +455,14 @@ contract TrebleSwapTest is BaseTest {
     {
         vm.startPrank(solverEOA);
         // Make sure solver has 1 AtlETH bonded in Atlas
-        uint256 bonded = atlas.balanceOfBonded(solverEOA);
+        uint256 bonded = atlas.balanceOfCommitted(solverEOA);
         if (bonded < 1e18) {
             uint256 atlETHBalance = atlas.balanceOf(solverEOA);
             if (atlETHBalance < 1e18) {
                 deal(solverEOA, 1e18 - atlETHBalance);
                 atlas.deposit{ value: 1e18 - atlETHBalance }();
             }
-            atlas.bond(1e18 - bonded);
+            atlas.commit(1e18 - bonded);
         }
 
         // Deploy solver contract

--- a/test/base/builders/SolverOperationBuilder.sol
+++ b/test/base/builders/SolverOperationBuilder.sol
@@ -112,7 +112,7 @@ contract SolverOperationBuilder is Test {
         return this;
     }
 
-    function depositAndBondAtlEth(
+    function depositAndCommitAtlEth(
         address from,
         address atlas,
         uint256 amount
@@ -121,13 +121,13 @@ contract SolverOperationBuilder is Test {
         returns (SolverOperationBuilder)
     {
         vm.prank(from);
-        IAtlas(atlas).depositAndBond{ value: amount }(amount);
+        IAtlas(atlas).depositAndCommit{ value: amount }(amount);
         return this;
     }
 
-    function depositAndBondAtlEth(address atlas, uint256 amount) public returns (SolverOperationBuilder) {
+    function depositAndCommitAtlEth(address atlas, uint256 amount) public returns (SolverOperationBuilder) {
         vm.prank(solverOperation.from);
-        IAtlas(atlas).depositAndBond{ value: amount }(amount);
+        IAtlas(atlas).depositAndCommit{ value: amount }(amount);
         return this;
     }
 


### PR DESCRIPTION
This PR updates the Atlas functions and events to align with ShMonad naming conventions as discussed in issue #504.

Changes:
- Rename  to 
- Rename  to  
- Rename  to 
- Rename  to 
- Update corresponding internal functions, events, and getters (e.g.,  -> )
- Update all occurrences in tests and scripts to reflect these changes.

Fixes #504