### PR TITLE
refactor: remove redundant receive() from Escrow.sol

### DIFF
--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -745,6 +745,4 @@ abstract contract Escrow is AtlETH {
         // No need to SafeCast - will revert above if too large for uint32
         ctx.dappGasLeft -= uint32(_gasUsed);
     }
-
-    receive() external payable { }
 }


### PR DESCRIPTION
The receive() function in Escrow.sol is unnecessary as AtlETH handles deposits via deposit(). Removing it prevents accidental direct ETH transfers that could get locked.