### PR TITLE
fix: remove receive() function from Escrow.sol

### DIFF
--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -746,5 +746,4 @@ abstract contract Escrow is AtlETH {
         ctx.dappGasLeft -= uint32(_gasUsed);
     }
 
-    receive() external payable { }
 }


### PR DESCRIPTION
As discussed in issue #506, removing the `receive()` function to reduce the risk of lost user funds from accidental transfers. Legitimate transfers are handled via payable function calls.