### PR TITLE
Cleanup: Remove redundant receive() in Escrow.sol

### DIFF
--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -746,5 +746,4 @@ abstract contract Escrow is AtlETH {
         ctx.dappGasLeft -= uint32(_gasUsed);
     }
 
-    receive() external payable { }
 }


### PR DESCRIPTION
The receive() function in Escrow.sol does not serve any purpose as legitimate fund transfers to Atlas are handled via specific payable function calls (like deposit()). Removing it reduces the risk of users accidentally sending funds directly to the contract and having them untracked. Fixes #506.