### PR TITLE
fix: prevent division by zero in GasAccounting and BaseGasCalculator

### DIFF
--- a/src/contracts/atlas/GasAccounting.sol
+++ b/src/contracts/atlas/GasAccounting.sol
@@ -165,7 +165,7 @@ abstract contract GasAccounting is SafetyLocks {
         }
 
         // Store solver's maxApprovedGasSpend for use in the _isBalanceReconciled() check
-        if (maxApprovedGasSpend > 0) {
+        if (maxApprovedGasSpend > 0 && tx.gasprice > 0) {
             // Convert maxApprovedGasSpend from wei (native token) units to gas units
             _gL.maxApprovedGasSpend = (maxApprovedGasSpend / tx.gasprice).toUint40();
             t_gasLedger = _gL.pack();
@@ -493,8 +493,11 @@ abstract contract GasAccounting is SafetyLocks {
             // - Gas (C + E) used by other reached solvers (bundler or solver fault failures)
             // - Gas (C only) used by unreached solvers
             // - Gas (E only) used during the bid-finding or unreached solver calldata charge loops
+            uint256 _unreachedCalldataGas;
+            if (tx.gasprice > 0) _unreachedCalldataGas = unreachedCalldataValuePaid / tx.gasprice;
+
             _winnerGasCharge = gasMarker - gL.writeoffsGas - gL.solverFaultFailureGas
-                - (unreachedCalldataValuePaid / tx.gasprice) - _gasLeft;
+                - _unreachedCalldataGas - _gasLeft;
             uint256 _surchargedGasPaidBySolvers = gL.solverFaultFailureGas + _winnerGasCharge;
 
             // Bundler gets base gas cost + bundler surcharge of (solver fault fails + winning solver charge)

--- a/src/contracts/gasCalculator/BaseGasCalculator.sol
+++ b/src/contracts/gasCalculator/BaseGasCalculator.sol
@@ -56,8 +56,10 @@ contract BaseGasCalculator is IL2GasCalculator, Ownable {
         calldataLength += uint256(_calldataLenOffset);
 
         // GasPriceOracle returns the upper bound of the L1 fee in wei, so we divide by the gas price to get the gas.
-        uint256 extraGas = IGasPriceOracle(GAS_PRICE_ORACLE).getL1FeeUpperBound(calldataLength) / tx.gasprice;
-        calldataGas += extraGas;
+        if (tx.gasprice > 0) {
+            uint256 extraGas = IGasPriceOracle(GAS_PRICE_ORACLE).getL1FeeUpperBound(calldataLength) / tx.gasprice;
+            calldataGas += extraGas;
+        }
     }
 
     /// @notice Gets the cost of initial gas used for a transaction with a different calldata fee than mainnet


### PR DESCRIPTION
This PR fixes potential division by zero errors in  and  that could occur on chains or in environments where  is 0. While Atlas is primarily used in MEV contexts where gas prices are typically non-zero, this change improves robustness and prevents unexpected reverts in zero-gas-price scenarios (e.g., local testing or specific L2 configurations).