### PR TITLE
refactor: remove non-existent functions from IAtlas interface

### DIFF
--- a/src/contracts/atlas/GasAccounting.sol
+++ b/src/contracts/atlas/GasAccounting.sol
@@ -165,7 +165,7 @@ abstract contract GasAccounting is SafetyLocks {
         }
 
         // Store solver's maxApprovedGasSpend for use in the _isBalanceReconciled() check
-        if (maxApprovedGasSpend > 0) {
+        if (maxApprovedGasSpend > 0 && tx.gasprice > 0) {
             // Convert maxApprovedGasSpend from wei (native token) units to gas units
             _gL.maxApprovedGasSpend = (maxApprovedGasSpend / tx.gasprice).toUint40();
             t_gasLedger = _gL.pack();
@@ -493,8 +493,11 @@ abstract contract GasAccounting is SafetyLocks {
             // - Gas (C + E) used by other reached solvers (bundler or solver fault failures)
             // - Gas (C only) used by unreached solvers
             // - Gas (E only) used during the bid-finding or unreached solver calldata charge loops
+            uint256 _unreachedCalldataGas;
+            if (tx.gasprice > 0) _unreachedCalldataGas = unreachedCalldataValuePaid / tx.gasprice;
+
             _winnerGasCharge = gasMarker - gL.writeoffsGas - gL.solverFaultFailureGas
-                - (unreachedCalldataValuePaid / tx.gasprice) - _gasLeft;
+                - _unreachedCalldataGas - _gasLeft;
             uint256 _surchargedGasPaidBySolvers = gL.solverFaultFailureGas + _winnerGasCharge;
 
             // Bundler gets base gas cost + bundler surcharge of (solver fault fails + winning solver charge)

--- a/src/contracts/gasCalculator/BaseGasCalculator.sol
+++ b/src/contracts/gasCalculator/BaseGasCalculator.sol
@@ -56,8 +56,10 @@ contract BaseGasCalculator is IL2GasCalculator, Ownable {
         calldataLength += uint256(_calldataLenOffset);
 
         // GasPriceOracle returns the upper bound of the L1 fee in wei, so we divide by the gas price to get the gas.
-        uint256 extraGas = IGasPriceOracle(GAS_PRICE_ORACLE).getL1FeeUpperBound(calldataLength) / tx.gasprice;
-        calldataGas += extraGas;
+        if (tx.gasprice > 0) {
+            uint256 extraGas = IGasPriceOracle(GAS_PRICE_ORACLE).getL1FeeUpperBound(calldataLength) / tx.gasprice;
+            calldataGas += extraGas;
+        }
     }
 
     /// @notice Gets the cost of initial gas used for a transaction with a different calldata fee than mainnet

--- a/src/contracts/interfaces/IAtlas.sol
+++ b/src/contracts/interfaces/IAtlas.sol
@@ -48,7 +48,6 @@ interface IAtlas {
     function withdrawSurcharge() external;
     function transferSurchargeRecipient(address newRecipient) external;
     function becomeSurchargeRecipient() external;
-    function setSurchargeRates(uint128 newAtlasRate, uint128 newBundlerRate) external;
 
     // Permit69.sol
     function transferUserERC20(
@@ -98,7 +97,6 @@ interface IAtlas {
         );
     function solverOpHashes(bytes32 opHash) external view returns (bool);
     function lock() external view returns (address activeEnvironment, uint32 callConfig, uint8 phase);
-    function solverLock() external view returns (uint256);
     function cumulativeSurcharge() external view returns (uint256);
     function surchargeRecipient() external view returns (address);
     function pendingSurchargeRecipient() external view returns (address);


### PR DESCRIPTION
As requested in issue #505, this PR removes functions from the IAtlas interface that are no longer implemented in the contracts.

Removed:
- setSurchargeRates(uint128,uint128)
- solverLock()

Fixes #505